### PR TITLE
refactor: new createCommit function interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ const addBobProposal: Proposal = {
 }
 
 // alice commits
-const commitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+const commitResult = await createCommit({ state: aliceGroup, cipherSuite: impl }, { extraProposals: [addBobProposal] })
 
 aliceGroup = commitResult.newState
 

--- a/docs/01-basic-functionality.md
+++ b/docs/01-basic-functionality.md
@@ -54,7 +54,7 @@ const addBobProposal: Proposal = {
   proposalType: "add",
   add: { keyPackage: bob.publicPackage },
 }
-const commitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+const commitResult = await createCommit({ state: aliceGroup, cipherSuite: impl }, { extraProposals: [addBobProposal] })
 aliceGroup = commitResult.newState
 
 // Bob joins using the welcome message

--- a/docs/02-ratchet-tree-extension.md
+++ b/docs/02-ratchet-tree-extension.md
@@ -51,7 +51,13 @@ const addBobProposal: Proposal = {
 }
 
 // Alice adds Bob with the ratchetTreeExtension = true
-const commitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl, true)
+const commitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  {
+    extraProposals: [addBobProposal],
+    ratchetTreeExtension: true,
+  },
+)
 aliceGroup = commitResult.newState
 
 // Bob joins using the welcome message and does not need to provide a ratchetTree

--- a/docs/03-three-party-join.md
+++ b/docs/03-three-party-join.md
@@ -56,7 +56,10 @@ const addBobProposal: Proposal = {
   add: { keyPackage: bob.publicPackage },
 }
 // Alice adds Bob and commits, this is epoch 1
-const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+const addBobCommitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  { extraProposals: [addBobProposal] },
+)
 
 if (addBobCommitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
 
@@ -77,7 +80,10 @@ const addCharlieProposal: Proposal = {
   add: { keyPackage: charlie.publicPackage },
 }
 // Alice adds Charlie, transitioning into epoch 2
-const addCharlieCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addCharlieProposal], impl)
+const addCharlieCommitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  { extraProposals: [addCharlieProposal] },
+)
 aliceGroup = addCharlieCommitResult.newState
 if (addCharlieCommitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
 

--- a/docs/04-remove.md
+++ b/docs/04-remove.md
@@ -51,7 +51,10 @@ const addBobProposal: Proposal = {
   proposalType: "add",
   add: { keyPackage: bob.publicPackage },
 }
-const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+const addBobCommitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  { extraProposals: [addBobProposal] },
+)
 aliceGroup = addBobCommitResult.newState
 
 // Bob joins the group, he is now also in epoch 1
@@ -69,7 +72,10 @@ const removeBobProposal: Proposal = {
   proposalType: "remove",
   remove: { removed: 1 }, // Bob's leaf index
 }
-const removeBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [removeBobProposal], impl)
+const removeBobCommitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  { extraProposals: [removeBobProposal] },
+)
 aliceGroup = removeBobCommitResult.newState
 if (removeBobCommitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
 

--- a/docs/05-update.md
+++ b/docs/05-update.md
@@ -52,7 +52,10 @@ const addBobProposal: Proposal = {
   proposalType: "add",
   add: { keyPackage: bob.publicPackage },
 }
-const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+const addBobCommitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  { extraProposals: [addBobProposal] },
+)
 aliceGroup = addBobCommitResult.newState
 
 // Bob joins the group, he is now also in epoch 1
@@ -66,7 +69,7 @@ let bobGroup = await joinGroup(
 )
 
 // Alice updates her key with an empty commit, transitioning to epoch 2
-const emptyCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [], impl)
+const emptyCommitResult = await createCommit({ state: aliceGroup, cipherSuite: impl })
 if (emptyCommitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
 aliceGroup = emptyCommitResult.newState
 
@@ -80,7 +83,7 @@ const bobProcessCommitResult = await processPrivateMessage(
 bobGroup = bobProcessCommitResult.newState
 
 // Bob updates his key with an empty commit, transitioning to epoch 3
-const emptyCommitResult3 = await createCommit(bobGroup, emptyPskIndex, false, [], impl)
+const emptyCommitResult3 = await createCommit({ state: aliceGroup, cipherSuite: impl })
 if (emptyCommitResult3.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
 bobGroup = emptyCommitResult3.newState
 

--- a/docs/06-multiple-joins-at-once.md
+++ b/docs/06-multiple-joins-at-once.md
@@ -55,7 +55,10 @@ const addCharlieProposal: Proposal = {
   proposalType: "add",
   add: { keyPackage: charlie.publicPackage },
 }
-const addCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal, addCharlieProposal], impl)
+const addCommitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  { extraProposals: [addBobProposal, addCharlieProposal] },
+)
 aliceGroup = addCommitResult.newState
 if (addCommitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
 

--- a/docs/07-external-join.md
+++ b/docs/07-external-join.md
@@ -57,7 +57,10 @@ const addBobProposal: Proposal = {
   proposalType: "add",
   add: { keyPackage: bob.publicPackage },
 }
-const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+const addBobCommitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  { extraProposals: [addBobProposal] },
+)
 aliceGroup = addBobCommitResult.newState
 
 // Bob joins the group, he is now also in epoch 1

--- a/docs/08-external-psk.md
+++ b/docs/08-external-psk.md
@@ -53,7 +53,10 @@ const addBobProposal: Proposal = {
   proposalType: "add",
   add: { keyPackage: bob.publicPackage },
 }
-const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+const addBobCommitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  { extraProposals: [addBobProposal] },
+)
 aliceGroup = addBobCommitResult.newState
 
 // Bob joins the group (epoch 1)
@@ -86,7 +89,14 @@ const base64PskId = bytesToBase64(pskId)
 const sharedPsks = { [base64PskId]: pskSecret }
 
 // Alice commits with the PSK proposal (epoch 2)
-const pskCommitResult = await createCommit(aliceGroup, makePskIndex(aliceGroup, sharedPsks), false, [pskProposal], impl)
+const pskCommitResult = await createCommit(
+  {
+    state: aliceGroup,
+    cipherSuite: impl,
+    pskIndex: makePskIndex(aliceGroup, sharedPsks),
+  },
+  { extraProposals: [pskProposal] },
+)
 aliceGroup = pskCommitResult.newState
 
 if (pskCommitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
@@ -180,11 +190,12 @@ const addBobProposal: Proposal = {
   add: { keyPackage: bob.publicPackage },
 }
 const commitResult = await createCommit(
-  aliceGroup,
-  makePskIndex(aliceGroup, sharedPsks),
-  false,
-  [addBobProposal, pskProposal],
-  impl,
+  {
+    state: aliceGroup,
+    cipherSuite: impl,
+    pskIndex: makePskIndex(aliceGroup, sharedPsks),
+  },
+  { extraProposals: [addBobProposal, pskProposal] },
 )
 aliceGroup = commitResult.newState
 

--- a/docs/09-resumption.md
+++ b/docs/09-resumption.md
@@ -52,7 +52,10 @@ const addBobProposal: Proposal = {
   proposalType: "add",
   add: { keyPackage: bob.publicPackage },
 }
-const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+const addBobCommitResult = await createCommit(
+  { state: aliceGroup, cipherSuite: impl },
+  { extraProposals: [addBobProposal] },
+)
 aliceGroup = addBobCommitResult.newState
 let bobGroup = await joinGroup(
   addBobCommitResult.welcome!,

--- a/docs/10-reinit.md
+++ b/docs/10-reinit.md
@@ -57,7 +57,7 @@ const addBobProposal: Proposal = {
   proposalType: "add",
   add: { keyPackage: bob.publicPackage },
 }
-const commitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+const commitResult = await createCommit({ state: aliceGroup, cipherSuite: impl }, { extraProposals: [addBobProposal] })
 aliceGroup = commitResult.newState
 
 // Bob joins the group (epoch 1)

--- a/src/createCommit.ts
+++ b/src/createCommit.ts
@@ -1,4 +1,4 @@
-import { addHistoricalReceiverData, throwIfDefined, validateRatchetTree } from "./clientState"
+import { addHistoricalReceiverData, makePskIndex, throwIfDefined, validateRatchetTree } from "./clientState"
 import { AuthenticatedContentCommit } from "./authenticatedContent"
 import {
   ClientState,
@@ -29,7 +29,7 @@ import { pathToPathSecrets } from "./pathSecrets"
 import { mergePrivateKeyPaths, updateLeafKey, toPrivateKeyPath, PrivateKeyPath } from "./privateKeyPath"
 import { Proposal, ProposalExternalInit } from "./proposal"
 import { ProposalOrRef } from "./proposalOrRefType"
-import { emptyPskIndex, PskIndex } from "./pskIndex"
+import { PskIndex } from "./pskIndex"
 import {
   RatchetTree,
   addLeafNode,
@@ -69,9 +69,9 @@ export interface CreateCommitOptions {
 }
 
 export async function createCommit(context: MLSContext, options?: CreateCommitOptions): Promise<CreateCommitResult> {
-  const { state, pskIndex = emptyPskIndex, cipherSuite } = context
+  const { state, pskIndex = makePskIndex(state, {}), cipherSuite } = context
   const {
-    wireAsPublicMessage,
+    wireAsPublicMessage = false,
     extraProposals = [],
     ratchetTreeExtension = false,
     authenticatedData = new Uint8Array(),
@@ -171,7 +171,7 @@ export async function createCommit(context: MLSContext, options?: CreateCommitOp
   }
 
   const [commit] = await protectCommit(
-    !!wireAsPublicMessage,
+    wireAsPublicMessage,
     state,
     authenticatedData,
     framedContent,

--- a/src/createCommit.ts
+++ b/src/createCommit.ts
@@ -29,7 +29,7 @@ import { pathToPathSecrets } from "./pathSecrets"
 import { mergePrivateKeyPaths, updateLeafKey, toPrivateKeyPath, PrivateKeyPath } from "./privateKeyPath"
 import { Proposal, ProposalExternalInit } from "./proposal"
 import { ProposalOrRef } from "./proposalOrRefType"
-import { PskIndex } from "./pskIndex"
+import { emptyPskIndex, PskIndex } from "./pskIndex"
 import {
   RatchetTree,
   addLeafNode,
@@ -48,29 +48,50 @@ import { CryptoVerificationError, InternalError, UsageError, ValidationError } f
 import { ClientConfig, defaultClientConfig } from "./clientConfig"
 import { Extension, extensionsSupportedByCapabilities } from "./extension"
 
+export interface MLSContext {
+  state: ClientState
+  cipherSuite: CiphersuiteImpl
+  pskIndex?: PskIndex
+}
+
 export interface CreateCommitResult {
   newState: ClientState
   welcome: Welcome | undefined
   commit: MLSMessage
 }
 
-export async function createCommit(
-  state: ClientState,
-  pskSearch: PskIndex,
-  publicMessage: boolean,
-  extraProposals: Proposal[],
-  cs: CiphersuiteImpl,
-  ratchetTreeExtension: boolean = false,
-  authenticatedData: Uint8Array = new Uint8Array(),
-  groupInfoExtensions: Extension[] = [],
-): Promise<CreateCommitResult> {
+export interface CreateCommitOptions {
+  wireAsPublicMessage?: boolean
+  extraProposals?: Proposal[]
+  ratchetTreeExtension?: boolean
+  groupInfoExtensions?: Extension[]
+  authenticatedData?: Uint8Array
+}
+
+export async function createCommit(context: MLSContext, options?: CreateCommitOptions): Promise<CreateCommitResult> {
+  const { state, pskIndex = emptyPskIndex, cipherSuite } = context
+  const {
+    wireAsPublicMessage,
+    extraProposals = [],
+    ratchetTreeExtension = false,
+    authenticatedData = new Uint8Array(),
+    groupInfoExtensions = [],
+  } = options ?? {}
+
   checkCanSendHandshakeMessages(state)
 
-  const wireformat = publicMessage ? "mls_public_message" : "mls_private_message"
+  const wireformat = wireAsPublicMessage ? "mls_public_message" : "mls_private_message"
 
   const allProposals = bundleAllProposals(state, extraProposals)
 
-  const res = await applyProposals(state, allProposals, toLeafIndex(state.privatePath.leafIndex), pskSearch, true, cs)
+  const res = await applyProposals(
+    state,
+    allProposals,
+    toLeafIndex(state.privatePath.leafIndex),
+    pskIndex,
+    true,
+    cipherSuite,
+  )
 
   if (res.additionalResult.kind === "externalCommit") throw new UsageError("Cannot create externalCommit as a member")
 
@@ -82,7 +103,7 @@ export async function createCommit(
         toLeafIndex(state.privatePath.leafIndex),
         state.groupContext,
         state.signaturePrivateKey,
-        cs,
+        cipherSuite,
       )
     : [res.tree, undefined, [] as PathSecret[], undefined]
 
@@ -95,17 +116,17 @@ export async function createCommit(
 
   const privateKeys = mergePrivateKeyPaths(
     newPrivateKey !== undefined
-      ? updateLeafKey(state.privatePath, await cs.hpke.exportPrivateKey(newPrivateKey))
+      ? updateLeafKey(state.privatePath, await cipherSuite.hpke.exportPrivateKey(newPrivateKey))
       : state.privatePath,
-    await toPrivateKeyPath(pathToPathSecrets(pathSecrets), state.privatePath.leafIndex, cs),
+    await toPrivateKeyPath(pathToPathSecrets(pathSecrets), state.privatePath.leafIndex, cipherSuite),
   )
 
   const lastPathSecret = pathSecrets.at(-1)
 
   const commitSecret =
     lastPathSecret === undefined
-      ? new Uint8Array(cs.kdf.size)
-      : await deriveSecret(lastPathSecret.secret, "path", cs.kdf)
+      ? new Uint8Array(cipherSuite.kdf.size)
+      : await deriveSecret(lastPathSecret.secret, "path", cipherSuite.kdf)
 
   const { signature, framedContent } = await createContentCommitSignature(
     state.groupContext,
@@ -114,10 +135,10 @@ export async function createCommit(
     { senderType: "member", leafIndex: state.privatePath.leafIndex },
     authenticatedData,
     state.signaturePrivateKey,
-    cs.signature,
+    cipherSuite.signature,
   )
 
-  const treeHash = await treeHashRoot(tree, cs.hash)
+  const treeHash = await treeHashRoot(tree, cipherSuite.hash)
 
   const updatedGroupContext = await nextEpochContext(
     groupContextWithExtensions,
@@ -126,7 +147,7 @@ export async function createCommit(
     signature,
     treeHash,
     state.confirmationTag,
-    cs.hash,
+    cipherSuite.hash,
   )
 
   const epochSecrets = await initializeEpoch(
@@ -134,13 +155,13 @@ export async function createCommit(
     commitSecret,
     updatedGroupContext,
     res.pskSecret,
-    cs.kdf,
+    cipherSuite.kdf,
   )
 
   const confirmationTag = await createConfirmationTag(
     epochSecrets.keySchedule.confirmationKey,
     updatedGroupContext.confirmedTranscriptHash,
-    cs.hash,
+    cipherSuite.hash,
   )
 
   const authData: FramedContentAuthDataCommit = {
@@ -149,7 +170,14 @@ export async function createCommit(
     confirmationTag,
   }
 
-  const [commit] = await protectCommit(publicMessage, state, authenticatedData, framedContent, authData, cs)
+  const [commit] = await protectCommit(
+    !!wireAsPublicMessage,
+    state,
+    authenticatedData,
+    framedContent,
+    authData,
+    cipherSuite,
+  )
 
   const welcome: Welcome | undefined = await createWelcome(
     ratchetTreeExtension,
@@ -157,7 +185,7 @@ export async function createCommit(
     confirmationTag,
     state,
     tree,
-    cs,
+    cipherSuite,
     epochSecrets,
     res,
     pathSecrets,
@@ -173,7 +201,11 @@ export async function createCommit(
   const newState: ClientState = {
     groupContext: updatedGroupContext,
     ratchetTree: tree,
-    secretTree: await createSecretTree(leafWidth(tree.length), epochSecrets.keySchedule.encryptionSecret, cs.kdf),
+    secretTree: await createSecretTree(
+      leafWidth(tree.length),
+      epochSecrets.keySchedule.encryptionSecret,
+      cipherSuite.kdf,
+    ),
     keySchedule: epochSecrets.keySchedule,
     privatePath: privateKeys,
     unappliedProposals: {},

--- a/src/resumption.ts
+++ b/src/resumption.ts
@@ -31,7 +31,16 @@ export async function reinitGroup(
     },
   }
 
-  return createCommit(state, makePskIndex(state, {}), false, [reinitProposal], cs)
+  return createCommit(
+    {
+      state,
+      pskIndex: makePskIndex(state, {}),
+      cipherSuite: cs,
+    },
+    {
+      extraProposals: [reinitProposal],
+    },
+  )
 }
 
 export async function reinitCreateNewGroup(
@@ -61,7 +70,16 @@ export async function reinitCreateNewGroup(
     },
   }
 
-  return createCommit(newGroup, makePskIndex(state, {}), false, [...addProposals, resumptionPsk], cs)
+  return createCommit(
+    {
+      state: newGroup,
+      pskIndex: makePskIndex(state, {}),
+      cipherSuite: cs,
+    },
+    {
+      extraProposals: [...addProposals, resumptionPsk],
+    },
+  )
 }
 
 export function makeResumptionPsk(
@@ -112,7 +130,16 @@ export async function branchGroup(
     },
   }
 
-  return createCommit(newGroup, pskSearch, false, [...addMemberProposals, branchPskProposal], cs)
+  return createCommit(
+    {
+      state: newGroup,
+      pskIndex: pskSearch,
+      cipherSuite: cs,
+    },
+    {
+      extraProposals: [...addMemberProposals, branchPskProposal],
+    },
+  )
 }
 
 export async function joinGroupFromBranch(

--- a/test/scenario/customExtensions.test.ts
+++ b/test/scenario/customExtensions.test.ts
@@ -55,11 +55,19 @@ async function customExtensionTest(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
-  let bobGroup = await joinGroup(
+  const bobGroup = await joinGroup(
     addBobCommitResult.welcome!,
     bob.publicPackage,
     bob.privatePackage,
@@ -83,7 +91,13 @@ async function customExtensionTest(cipherSuite: CiphersuiteName) {
     },
   }
 
-  await expect(createCommit(aliceGroup, emptyPskIndex, false, [addCharlieProposal], impl)).rejects.toThrow(
-    ValidationError,
-  )
+  await expect(
+    createCommit(
+      {
+        state: aliceGroup,
+        cipherSuite: impl,
+      },
+      { extraProposals: [addCharlieProposal] },
+    ),
+  ).rejects.toThrow(ValidationError)
 }

--- a/test/scenario/customProposal.test.ts
+++ b/test/scenario/customProposal.test.ts
@@ -48,7 +48,13 @@ async function customProposalTest(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    { extraProposals: [addBobProposal] },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
@@ -89,9 +95,13 @@ async function customProposalTest(cipherSuite: CiphersuiteName) {
   aliceGroup = processProposalResult.newState
 
   //creating an application message will fail now
-  expect(createApplicationMessage(aliceGroup, new Uint8Array([1, 2, 3]), impl)).rejects.toThrow(UsageError)
+  await expect(createApplicationMessage(aliceGroup, new Uint8Array([1, 2, 3]), impl)).rejects.toThrow(UsageError)
 
-  const createCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [], impl)
+  const createCommitResult = await createCommit({
+    state: aliceGroup,
+
+    cipherSuite: impl,
+  })
 
   aliceGroup = createCommitResult.newState
 

--- a/test/scenario/epochOutOfOrder.test.ts
+++ b/test/scenario/epochOutOfOrder.test.ts
@@ -70,7 +70,16 @@ async function setupTestParticipants(
   }
 
   // alice adds bob and initiates epoch 1
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl, true)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+      ratchetTreeExtension: true,
+    },
+  )
   aliceGroup = addBobCommitResult.newState
 
   // bob joins at epoch 1
@@ -112,7 +121,10 @@ async function epochOutOfOrder(cipherSuite: CiphersuiteName) {
   aliceGroup = aliceCreateFirstProposalResult.newState
 
   // bob creates an empty commit and goes to epoch 2
-  const emptyCommitResult1 = await createCommit(bobGroup, emptyPskIndex, false, [], impl)
+  const emptyCommitResult1 = await createCommit({
+    state: bobGroup,
+    cipherSuite: impl,
+  })
   bobGroup = emptyCommitResult1.newState
 
   if (emptyCommitResult1.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
@@ -131,7 +143,10 @@ async function epochOutOfOrder(cipherSuite: CiphersuiteName) {
   aliceGroup = aliceCreateSecondMessageResult.newState
 
   // bob creates an empty commit and goes to epoch 3
-  const emptyCommitResult2 = await createCommit(bobGroup, emptyPskIndex, false, [], impl)
+  const emptyCommitResult2 = await createCommit({
+    state: bobGroup,
+    cipherSuite: impl,
+  })
   bobGroup = emptyCommitResult2.newState
 
   if (emptyCommitResult2.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
@@ -150,7 +165,10 @@ async function epochOutOfOrder(cipherSuite: CiphersuiteName) {
   aliceGroup = aliceCreateThirdMessageResult.newState
 
   // bob creates an empty commit and goes to epoch 4
-  const emptyCommitResult3 = await createCommit(bobGroup, emptyPskIndex, false, [], impl)
+  const emptyCommitResult3 = await createCommit({
+    state: bobGroup,
+    cipherSuite: impl,
+  })
   bobGroup = emptyCommitResult3.newState
 
   if (emptyCommitResult3.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
@@ -196,7 +214,7 @@ async function epochOutOfOrder(cipherSuite: CiphersuiteName) {
   if (aliceCreateFirstProposalResult.message.wireformat !== "mls_private_message")
     throw new Error("Expected private message")
 
-  expect(
+  await expect(
     processPrivateMessage(bobGroup, aliceCreateFirstProposalResult.message.privateMessage, emptyPskIndex, impl),
   ).rejects.toThrow(ValidationError)
 
@@ -211,14 +229,17 @@ async function epochOutOfOrderRandom(cipherSuite: CiphersuiteName, totalMessages
 
   const message = new TextEncoder().encode("Hi!")
 
-  let messages: PrivateMessage[] = []
+  const messages: PrivateMessage[] = []
   for (let i = 0; i < totalMessages; i++) {
     const createMessageResult = await createApplicationMessage(aliceGroup, message, impl)
     // alice sends the first message in current epoch
     aliceGroup = createMessageResult.newState
 
     // bob creates an empty commit and goes to next epoch
-    const emptyCommitResult = await createCommit(bobGroup, emptyPskIndex, false, [], impl)
+    const emptyCommitResult = await createCommit({
+      state: bobGroup,
+      cipherSuite: impl,
+    })
     bobGroup = emptyCommitResult.newState
 
     if (emptyCommitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
@@ -257,14 +278,17 @@ async function epochOutOfOrderLimitFails(cipherSuite: CiphersuiteName, totalMess
 
   const message = new TextEncoder().encode("Hi!")
 
-  let messages: PrivateMessage[] = []
+  const messages: PrivateMessage[] = []
   for (let i = 0; i < totalMessages; i++) {
     const createMessageResult = await createApplicationMessage(aliceGroup, message, impl)
     // alice sends the first message in current epoch
     aliceGroup = createMessageResult.newState
 
     // bob creates an empty commit and goes to next epoch
-    const emptyCommitResult = await createCommit(bobGroup, emptyPskIndex, false, [], impl)
+    const emptyCommitResult = await createCommit({
+      state: bobGroup,
+      cipherSuite: impl,
+    })
     bobGroup = emptyCommitResult.newState
 
     if (emptyCommitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")

--- a/test/scenario/externalAddProposal.test.ts
+++ b/test/scenario/externalAddProposal.test.ts
@@ -55,7 +55,13 @@ async function externalAddProposalTest(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    { extraProposals: [addBobProposal] },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
@@ -93,7 +99,10 @@ async function externalAddProposalTest(cipherSuite: CiphersuiteName) {
 
   bobGroup = bobProcessCharlieProposalResult.newState
 
-  const addCharlieCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [], impl)
+  const addCharlieCommitResult = await createCommit({
+    state: aliceGroup,
+    cipherSuite: impl,
+  })
 
   aliceGroup = addCharlieCommitResult.newState
 
@@ -110,7 +119,7 @@ async function externalAddProposalTest(cipherSuite: CiphersuiteName) {
 
   expect(bobGroup.keySchedule.epochAuthenticator).toStrictEqual(aliceGroup.keySchedule.epochAuthenticator)
 
-  let charlieGroup = await joinGroup(
+  const charlieGroup = await joinGroup(
     addCharlieCommitResult.welcome!,
     charlie.publicPackage,
     charlie.privatePackage,

--- a/test/scenario/externalJoin.test.ts
+++ b/test/scenario/externalJoin.test.ts
@@ -42,7 +42,15 @@ async function externalJoin(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
@@ -67,7 +75,7 @@ async function externalJoin(cipherSuite: CiphersuiteName) {
     impl,
   )
 
-  let charlieGroup = charlieJoinGroupCommitResult.newState
+  const charlieGroup = charlieJoinGroupCommitResult.newState
 
   const aliceProcessCharlieJoinResult = await processPublicMessage(
     aliceGroup,

--- a/test/scenario/externalJoinResync.test.ts
+++ b/test/scenario/externalJoinResync.test.ts
@@ -50,12 +50,14 @@ async function externalJoinResyncTest(cipherSuite: CiphersuiteName) {
   }
 
   const addBobAndCharlieCommitResult = await createCommit(
-    aliceGroup,
-    emptyPskIndex,
-    false,
-    [addBobProposal, addCharlieProposal],
-    impl,
-    true,
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal, addCharlieProposal],
+      ratchetTreeExtension: true,
+    },
   )
 
   aliceGroup = addBobAndCharlieCommitResult.newState

--- a/test/scenario/externalProposal.test.ts
+++ b/test/scenario/externalProposal.test.ts
@@ -54,7 +54,15 @@ async function externalProposalTest(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
@@ -105,7 +113,10 @@ async function externalProposalTest(cipherSuite: CiphersuiteName) {
 
   bobGroup = bobProcessCharlieProposalResult.newState
 
-  const removeBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [], impl)
+  const removeBobCommitResult = await createCommit({
+    state: aliceGroup,
+    cipherSuite: impl,
+  })
 
   aliceGroup = removeBobCommitResult.newState
 

--- a/test/scenario/externalPsk.test.ts
+++ b/test/scenario/externalPsk.test.ts
@@ -39,7 +39,15 @@ async function externalPsk(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const commitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const commitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = commitResult.newState
 
@@ -89,11 +97,14 @@ async function externalPsk(cipherSuite: CiphersuiteName) {
   const sharedPsks = { [base64PskId1]: pskSecret1, [base64PskId2]: pskSecret2 }
 
   const pskCommitResult = await createCommit(
-    aliceGroup,
-    makePskIndex(aliceGroup, sharedPsks),
-    false,
-    [pskProposal1, pskProposal2],
-    impl,
+    {
+      state: aliceGroup,
+      pskIndex: makePskIndex(aliceGroup, sharedPsks),
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [pskProposal1, pskProposal2],
+    },
   )
 
   aliceGroup = pskCommitResult.newState

--- a/test/scenario/externalPskJoin.test.ts
+++ b/test/scenario/externalPskJoin.test.ts
@@ -58,16 +58,19 @@ async function externalPskJoin(cipherSuite: CiphersuiteName) {
   const sharedPsks = { [base64PskId]: pskSecret }
 
   const commitResult = await createCommit(
-    aliceGroup,
-    makePskIndex(aliceGroup, sharedPsks),
-    false,
-    [addBobProposal, pskProposal],
-    impl,
+    {
+      state: aliceGroup,
+      pskIndex: makePskIndex(aliceGroup, sharedPsks),
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal, pskProposal],
+    },
   )
 
   aliceGroup = commitResult.newState
 
-  let bobGroup = await joinGroup(
+  const bobGroup = await joinGroup(
     commitResult.welcome!,
     bob.publicPackage,
     bob.privatePackage,

--- a/test/scenario/generationOutOfOrder.test.ts
+++ b/test/scenario/generationOutOfOrder.test.ts
@@ -64,7 +64,16 @@ async function setupTestParticipants(
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl, true)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+      ratchetTreeExtension: true,
+    },
+  )
   aliceGroup = addBobCommitResult.newState
 
   const bobGroup = await joinGroup(
@@ -139,7 +148,7 @@ async function generationOutOfOrderRandom(cipherSuite: CiphersuiteName, totalMes
 
   const message = new TextEncoder().encode("Hi!")
 
-  let messages: PrivateMessage[] = []
+  const messages: PrivateMessage[] = []
   for (let i = 0; i < totalMessages; i++) {
     const createMessageResult = await createApplicationMessage(aliceGroup, message, impl)
     aliceGroup = createMessageResult.newState
@@ -169,7 +178,7 @@ async function generationOutOfOrderLimitFails(cipherSuite: CiphersuiteName, tota
 
   const message = new TextEncoder().encode("Hi!")
 
-  let messages: PrivateMessage[] = []
+  const messages: PrivateMessage[] = []
   for (let i = 0; i < totalMessages + 1; i++) {
     const createMessageResult = await createApplicationMessage(aliceGroup, message, impl)
     aliceGroup = createMessageResult.newState

--- a/test/scenario/grease.test.ts
+++ b/test/scenario/grease.test.ts
@@ -45,11 +45,19 @@ async function greaseTest(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
-  let bobGroup = await joinGroup(
+  const bobGroup = await joinGroup(
     addBobCommitResult.welcome!,
     bob.publicPackage,
     bob.privatePackage,

--- a/test/scenario/largeGroupFullLifecycle.test.ts
+++ b/test/scenario/largeGroupFullLifecycle.test.ts
@@ -92,7 +92,15 @@ async function largeGroupFullLifecycle(cipherSuite: CiphersuiteName, initialSize
       },
     }
 
-    const commitResult = await createCommit(remover.state, emptyPskIndex, false, [removeProposal], impl)
+    const commitResult = await createCommit(
+      {
+        state: remover.state,
+        cipherSuite: impl,
+      },
+      {
+        extraProposals: [removeProposal],
+      },
+    )
 
     if (commitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
     remover.state = commitResult.newState
@@ -135,7 +143,15 @@ async function addMember(memberStates: MemberState[], index: number, impl: Ciphe
     add: { keyPackage: newKP.publicPackage },
   }
 
-  const commitResult = await createCommit(adder.state, emptyPskIndex, false, [addProposal], impl)
+  const commitResult = await createCommit(
+    {
+      state: adder.state,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addProposal],
+    },
+  )
 
   if (commitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
 
@@ -171,7 +187,10 @@ async function addMember(memberStates: MemberState[], index: number, impl: Ciphe
 async function update(memberStates: MemberState[], updateIndex: number, impl: CiphersuiteImpl) {
   const updater = memberStates[updateIndex]!
 
-  const emptyCommitResult = await createCommit(updater.state, emptyPskIndex, false, [], impl)
+  const emptyCommitResult = await createCommit({
+    state: updater.state,
+    cipherSuite: impl,
+  })
 
   updater.state = emptyCommitResult.newState
 

--- a/test/scenario/leaveProposal.test.ts
+++ b/test/scenario/leaveProposal.test.ts
@@ -54,12 +54,15 @@ async function leaveProposal(cipherSuite: CiphersuiteName, publicMessage: boolea
   }
 
   const addBobAndCharlieCommitResult = await createCommit(
-    aliceGroup,
-    emptyPskIndex,
-    publicMessage,
-    [addBobProposal, addCharlieProposal],
-    impl,
-    true,
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      wireAsPublicMessage: publicMessage,
+      extraProposals: [addBobProposal, addCharlieProposal],
+      ratchetTreeExtension: true,
+    },
   )
 
   aliceGroup = addBobAndCharlieCommitResult.newState
@@ -117,7 +120,16 @@ async function leaveProposal(cipherSuite: CiphersuiteName, publicMessage: boolea
   charlieGroup = charlieProcessProposalResult.newState
 
   //bob commits to alice leaving
-  const bobCommitResult = await createCommit(bobGroup, emptyPskIndex, publicMessage, [], impl, false)
+  const bobCommitResult = await createCommit(
+    {
+      state: bobGroup,
+      cipherSuite: impl,
+    },
+    {
+      wireAsPublicMessage: publicMessage,
+      ratchetTreeExtension: false,
+    },
+  )
 
   bobGroup = bobCommitResult.newState
 

--- a/test/scenario/multipleJoinsAtOnce.test.ts
+++ b/test/scenario/multipleJoinsAtOnce.test.ts
@@ -48,16 +48,18 @@ async function multipleJoinsAtOnce(cipherSuite: CiphersuiteName) {
   }
 
   const addBobAndCharlieCommitResult = await createCommit(
-    aliceGroup,
-    emptyPskIndex,
-    false,
-    [addBobProposal, addCharlieProposal],
-    impl,
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal, addCharlieProposal],
+    },
   )
 
   aliceGroup = addBobAndCharlieCommitResult.newState
 
-  let bobGroup = await joinGroup(
+  const bobGroup = await joinGroup(
     addBobAndCharlieCommitResult.welcome!,
     bob.publicPackage,
     bob.privatePackage,
@@ -68,7 +70,7 @@ async function multipleJoinsAtOnce(cipherSuite: CiphersuiteName) {
 
   expect(bobGroup.keySchedule.epochAuthenticator).toStrictEqual(aliceGroup.keySchedule.epochAuthenticator)
 
-  let charlieGroup = await joinGroup(
+  const charlieGroup = await joinGroup(
     addBobAndCharlieCommitResult.welcome!,
     charlie.publicPackage,
     charlie.privatePackage,

--- a/test/scenario/oneToOneJoin.test.ts
+++ b/test/scenario/oneToOneJoin.test.ts
@@ -53,7 +53,15 @@ async function oneToOne(cipherSuite: CiphersuiteName) {
   }
 
   // alice commits
-  const commitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const commitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = commitResult.newState
 

--- a/test/scenario/ratchetTreeExtension.test.ts
+++ b/test/scenario/ratchetTreeExtension.test.ts
@@ -48,17 +48,19 @@ async function ratchetTreeExtension(cipherSuite: CiphersuiteName) {
   }
 
   const addBobAndCharlieCommitResult = await createCommit(
-    aliceGroup,
-    emptyPskIndex,
-    false,
-    [addBobProposal, addCharlieProposal],
-    impl,
-    true,
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal, addCharlieProposal],
+      ratchetTreeExtension: true,
+    },
   )
 
   aliceGroup = addBobAndCharlieCommitResult.newState
 
-  let bobGroup = await joinGroup(
+  const bobGroup = await joinGroup(
     addBobAndCharlieCommitResult.welcome!,
     bob.publicPackage,
     bob.privatePackage,
@@ -68,7 +70,7 @@ async function ratchetTreeExtension(cipherSuite: CiphersuiteName) {
 
   expect(bobGroup.keySchedule.epochAuthenticator).toStrictEqual(aliceGroup.keySchedule.epochAuthenticator)
 
-  let charlieGroup = await joinGroup(
+  const charlieGroup = await joinGroup(
     addBobAndCharlieCommitResult.welcome!,
     charlie.publicPackage,
     charlie.privatePackage,

--- a/test/scenario/reinit.test.ts
+++ b/test/scenario/reinit.test.ts
@@ -40,7 +40,15 @@ async function reinit(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const commitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const commitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = commitResult.newState
 
@@ -76,7 +84,12 @@ async function reinit(cipherSuite: CiphersuiteName) {
   expect(aliceGroup.groupActiveState.kind).toBe("suspendedPendingReinit")
 
   //creating a message will fail now
-  await expect(createCommit(aliceGroup, emptyPskIndex, false, [], impl)).rejects.toThrow(UsageError)
+  await expect(
+    createCommit({
+      state: aliceGroup,
+      cipherSuite: impl,
+    }),
+  ).rejects.toThrow(UsageError)
 
   const newImpl = await getCiphersuiteImpl(getCiphersuiteFromName(newCiphersuite))
 

--- a/test/scenario/rejectIncomingMessage.test.ts
+++ b/test/scenario/rejectIncomingMessage.test.ts
@@ -41,7 +41,16 @@ async function rejectIncomingMessagesTest(cipherSuite: CiphersuiteName, publicMe
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, publicMessage, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      wireAsPublicMessage: publicMessage,
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
@@ -90,7 +99,15 @@ async function rejectIncomingMessagesTest(cipherSuite: CiphersuiteName, publicMe
   expect(aliceGroup.unappliedProposals).toStrictEqual({})
 
   // alice commits without the proposal
-  const aliceCommitResult = await createCommit(aliceGroup, emptyPskIndex, publicMessage, [], impl)
+  const aliceCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      wireAsPublicMessage: publicMessage,
+    },
+  )
 
   aliceGroup = aliceCommitResult.newState
 

--- a/test/scenario/remove.test.ts
+++ b/test/scenario/remove.test.ts
@@ -50,11 +50,13 @@ async function remove(cipherSuite: CiphersuiteName) {
   }
 
   const addBobAndCharlieCommitResult = await createCommit(
-    aliceGroup,
-    emptyPskIndex,
-    false,
-    [addBobProposal, addCharlieProposal],
-    impl,
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal, addCharlieProposal],
+    },
   )
 
   aliceGroup = addBobAndCharlieCommitResult.newState
@@ -88,7 +90,15 @@ async function remove(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const removeBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [removeBobProposal], impl)
+  const removeBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [removeBobProposal],
+    },
+  )
 
   aliceGroup = removeBobCommitResult.newState
 
@@ -116,7 +126,12 @@ async function remove(cipherSuite: CiphersuiteName) {
   expect(bobGroup.groupActiveState).toStrictEqual({ kind: "removedFromGroup" })
 
   //creating a message will fail now
-  expect(createCommit(bobGroup, emptyPskIndex, false, [], impl)).rejects.toThrow(UsageError)
+  await expect(
+    createCommit({
+      state: bobGroup,
+      cipherSuite: impl,
+    }),
+  ).rejects.toThrow(UsageError)
 
   await cannotMessageAnymore(bobGroup, impl)
 

--- a/test/scenario/requiredCapabilites.test.ts
+++ b/test/scenario/requiredCapabilites.test.ts
@@ -74,11 +74,19 @@ async function requiredCapatabilitiesTest(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
-  let bobGroup = await joinGroup(
+  const bobGroup = await joinGroup(
     addBobCommitResult.welcome!,
     bob.publicPackage,
     bob.privatePackage,
@@ -96,7 +104,15 @@ async function requiredCapatabilitiesTest(cipherSuite: CiphersuiteName) {
     },
   }
 
-  await expect(createCommit(aliceGroup, emptyPskIndex, false, [addCharlieProposal], impl)).rejects.toThrow(
-    ValidationError,
-  )
+  await expect(
+    createCommit(
+      {
+        state: aliceGroup,
+        cipherSuite: impl,
+      },
+      {
+        extraProposals: [addCharlieProposal],
+      },
+    ),
+  ).rejects.toThrow(ValidationError)
 }

--- a/test/scenario/resumption.test.ts
+++ b/test/scenario/resumption.test.ts
@@ -38,7 +38,15 @@ async function resumption(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const commitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const commitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = commitResult.newState
 

--- a/test/scenario/threePartyJoin.test.ts
+++ b/test/scenario/threePartyJoin.test.ts
@@ -41,7 +41,15 @@ async function threePartyJoin(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
@@ -63,7 +71,15 @@ async function threePartyJoin(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addCharlieCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addCharlieProposal], impl)
+  const addCharlieCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addCharlieProposal],
+    },
+  )
 
   aliceGroup = addCharlieCommitResult.newState
 
@@ -80,7 +96,7 @@ async function threePartyJoin(cipherSuite: CiphersuiteName) {
 
   expect(bobGroup.keySchedule.epochAuthenticator).toStrictEqual(aliceGroup.keySchedule.epochAuthenticator)
 
-  let charlieGroup = await joinGroup(
+  const charlieGroup = await joinGroup(
     addCharlieCommitResult.welcome!,
     charlie.publicPackage,
     charlie.privatePackage,

--- a/test/scenario/update.test.ts
+++ b/test/scenario/update.test.ts
@@ -38,7 +38,15 @@ async function update(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const addBobCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const addBobCommitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    {
+      extraProposals: [addBobProposal],
+    },
+  )
 
   aliceGroup = addBobCommitResult.newState
 
@@ -53,7 +61,10 @@ async function update(cipherSuite: CiphersuiteName) {
 
   expect(bobGroup.keySchedule.epochAuthenticator).toStrictEqual(aliceGroup.keySchedule.epochAuthenticator)
 
-  const emptyCommitResult = await createCommit(aliceGroup, emptyPskIndex, false, [], impl)
+  const emptyCommitResult = await createCommit({
+    state: aliceGroup,
+    cipherSuite: impl,
+  })
 
   if (emptyCommitResult.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
 
@@ -68,7 +79,10 @@ async function update(cipherSuite: CiphersuiteName) {
 
   bobGroup = bobProcessCommitResult.newState
 
-  const emptyCommitResult3 = await createCommit(bobGroup, emptyPskIndex, false, [], impl)
+  const emptyCommitResult3 = await createCommit({
+    state: bobGroup,
+    cipherSuite: impl,
+  })
 
   if (emptyCommitResult3.commit.wireformat !== "mls_private_message") throw new Error("Expected private message")
 

--- a/test/validation/resumptionValidation.test.ts
+++ b/test/validation/resumptionValidation.test.ts
@@ -41,7 +41,13 @@ async function reinitValidation(cipherSuite: CiphersuiteName) {
     },
   }
 
-  const commitResult = await createCommit(aliceGroup, emptyPskIndex, false, [addBobProposal], impl)
+  const commitResult = await createCommit(
+    {
+      state: aliceGroup,
+      cipherSuite: impl,
+    },
+    { extraProposals: [addBobProposal] },
+  )
 
   aliceGroup = commitResult.newState
 
@@ -54,7 +60,10 @@ async function reinitValidation(cipherSuite: CiphersuiteName) {
     aliceGroup.ratchetTree,
   )
 
-  const bobCommitResult = await createCommit(bobGroup, emptyPskIndex, false, [], impl)
+  const bobCommitResult = await createCommit({
+    state: bobGroup,
+    cipherSuite: impl,
+  })
 
   bobGroup = bobCommitResult.newState
 


### PR DESCRIPTION
Connects to #76 

1. Refactored `createCommit` to have context + options arguments format.
2. Fixed some lintiing issues along the way