### PR TITLE
Expose all files in package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,18 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./*.js": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This PR expands the `exports` field in the `package.json` so its possible to import all of the exports of specific parts of the library instead of needing to import everything through `index.ts`