### PR TITLE
Remove noble/curves dependency for Ed25519

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add ts-mls
 pnpm add ts-mls
 ```
 
-This project currently only has a single dependency, `@hpke/core`. However, to support different Ciphersuites, you may need to install other libraries. As an example, to use the `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` Ciphersuite, you would also have to install `@noble/curves`:
+This project currently only has a single dependency, `@hpke/core`. However, to support different Ciphersuites, you may need to install other libraries. As an example, to use the `MLS_128_DHKEMP256_AES128GCM_SHA256_P256` Ciphersuite, you would also have to install `@noble/curves`:
 
 ```bash
 # npm
@@ -42,21 +42,21 @@ The following cipher suites are supported:
 
 | KEM                      | AEAD             | KDF         | Hash    | Signature | Name                                                | ID  | Dependencies                                                        |
 | ------------------------ | ---------------- | ----------- | ------- | --------- | --------------------------------------------------- | --- | ------------------------------------------------------------------- |
-| DHKEM-X25519-HKDF-SHA256 | AES128GCM        | HKDF-SHA256 | SHA-256 | Ed25519   | MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519        | 1   | @noble/curves                                                       |
+| DHKEM-X25519-HKDF-SHA256 | AES128GCM        | HKDF-SHA256 | SHA-256 | Ed25519   | MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519        | 1   |                                                                     |
 | DHKEM-P256-HKDF-SHA256   | AES128GCM        | HKDF-SHA256 | SHA-256 | P256      | MLS_128_DHKEMP256_AES128GCM_SHA256_P256             | 2   | @noble/curves                                                       |
 | DHKEM-X25519-HKDF-SHA256 | CHACHA20POLY1305 | HKDF-SHA256 | SHA-256 | Ed25519   | MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 | 3   | @hpke/chacha20poly1305, @noble/curves                               |
 | DHKEM-X448-HKDF-SHA512   | AES256GCM        | HKDF-SHA512 | SHA-512 | Ed448     | MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448            | 4   | @noble/curves                                                       |
 | DHKEM-P521-HKDF-SHA512   | AES256GCM        | HKDF-SHA512 | SHA-512 | P521      | MLS_256_DHKEMP521_AES256GCM_SHA512_P521             | 5   | @noble/curves                                                       |
 | DHKEM-X448-HKDF-SHA512   | CHACHA20POLY1305 | HKDF-SHA512 | SHA-512 | Ed448     | MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448     | 6   | @hpke/chacha20poly1305, @noble/curves                               |
 | DHKEM-P384-HKDF-SHA384   | AES256GCM        | HKDF-SHA384 | SHA-384 | P384      | MLS_256_DHKEMP384_AES256GCM_SHA384_P384             | 7   | @noble/curves                                                       |
-| ML-KEM-512               | AES256GCM        | HKDF-SHA256 | SHA-256 | Ed25519   | MLS_128_MLKEM512_AES128GCM_SHA256_Ed25519           | 77  | @hpke/ml-kem, @noble/curves                                         |
-| ML-KEM-512               | CHACHA20POLY1305 | HKDF-SHA256 | SHA-256 | Ed25519   | MLS_128_MLKEM512_CHACHA20POLY1305_SHA256_Ed25519    | 78  | @hpke/ml-kem, @hpke/chacha20poly1305, @noble/curves                 |
-| ML-KEM-768               | AES256GCM        | HKDF-SHA384 | SHA-384 | Ed25519   | MLS_256_MLKEM768_AES256GCM_SHA384_Ed25519           | 79  | @hpke/ml-kem, @noble/curves                                         |
-| ML-KEM-768               | CHACHA20POLY1305 | HKDF-SHA384 | SHA-384 | Ed25519   | MLS_256_MLKEM768_CHACHA20POLY1305_SHA384_Ed25519    | 80  | @hpke/ml-kem, @hpke/chacha20poly1305, @noble/curves                 |
-| ML-KEM-1024              | AES256GCM        | HKDF-SHA512 | SHA-512 | Ed25519   | MLS_256_MLKEM1024_AES256GCM_SHA512_Ed25519          | 81  | @hpke/ml-kem, @noble/curves                                         |
-| ML-KEM-1024              | CHACHA20POLY1305 | HKDF-SHA512 | SHA-512 | Ed25519   | MLS_256_MLKEM1024_CHACHA20POLY1305_SHA512_Ed25519   | 82  | @hpke/ml-kem, @hpke/chacha20poly1305, @noble/curves                 |
-| X-Wing                   | AES256GCM        | HKDF-SHA512 | SHA-512 | Ed25519   | MLS_256_XWING_AES256GCM_SHA512_Ed25519              | 83  | @hpke/hybridkem-x-wing, @noble/curves                               |
-| X-Wing                   | CHACHA20POLY1305 | HKDF-SHA512 | SHA-512 | Ed25519   | MLS_256_XWING_CHACHA20POLY1305_SHA512_Ed25519       | 84  | @hpke/hybridkem-x-wing, @hpke/chacha20poly1305, @noble/curves       |
+| ML-KEM-512               | AES256GCM        | HKDF-SHA256 | SHA-256 | Ed25519   | MLS_128_MLKEM512_AES128GCM_SHA256_Ed25519           | 77  | @hpke/ml-kem                                                        |
+| ML-KEM-512               | CHACHA20POLY1305 | HKDF-SHA256 | SHA-256 | Ed25519   | MLS_128_MLKEM512_CHACHA20POLY1305_SHA256_Ed25519    | 78  | @hpke/ml-kem, @hpke/chacha20poly1305                                |
+| ML-KEM-768               | AES256GCM        | HKDF-SHA384 | SHA-384 | Ed25519   | MLS_256_MLKEM768_AES256GCM_SHA384_Ed25519           | 79  | @hpke/ml-kem                                                        |
+| ML-KEM-768               | CHACHA20POLY1305 | HKDF-SHA384 | SHA-384 | Ed25519   | MLS_256_MLKEM768_CHACHA20POLY1305_SHA384_Ed25519    | 80  | @hpke/ml-kem, @hpke/chacha20poly1305                                |
+| ML-KEM-1024              | AES256GCM        | HKDF-SHA512 | SHA-512 | Ed25519   | MLS_256_MLKEM1024_AES256GCM_SHA512_Ed25519          | 81  | @hpke/ml-kem                                                        |
+| ML-KEM-1024              | CHACHA20POLY1305 | HKDF-SHA512 | SHA-512 | Ed25519   | MLS_256_MLKEM1024_CHACHA20POLY1305_SHA512_Ed25519   | 82  | @hpke/ml-kem, @hpke/chacha20poly1305                                |
+| X-Wing                   | AES256GCM        | HKDF-SHA512 | SHA-512 | Ed25519   | MLS_256_XWING_AES256GCM_SHA512_Ed25519              | 83  | @hpke/hybridkem-x-wing                                              |
+| X-Wing                   | CHACHA20POLY1305 | HKDF-SHA512 | SHA-512 | Ed25519   | MLS_256_XWING_CHACHA20POLY1305_SHA512_Ed25519       | 84  | @hpke/hybridkem-x-wing, @hpke/chacha20poly1305                      |
 | ML-KEM-1024              | AES256GCM        | HKDF-SHA512 | SHA-512 | ML-DSA-87 | MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA78          | 85  | @hpke/ml-kem, @noble/post-quantum                                   |
 | ML-KEM-1024              | CHACHA20POLY1305 | HKDF-SHA512 | SHA-512 | ML-DSA-87 | MLS_256_MLKEM1024_CHACHA20POLY1305_SHA512_MLDSA78   | 86  | @hpke/ml-kem, @hpke/chacha20poly1305, @noble/post-quantum           |
 | X-Wing                   | AES256GCM        | HKDF-SHA512 | SHA-512 | ML-DSA-87 | MLS_256_XWING_AES256GCM_SHA512_MLDSA78              | 87  | @hpke/hybridkem-x-wing, @noble/post-quantum                         |

--- a/bench/results/basic.json
+++ b/bench/results/basic.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "Generate KeyPackage",
-    "avg": 1097,
-    "med": 1108,
-    "latencyAvg": 919225,
-    "latencyMed": 902812,
-    "samples": 1088
+    "avg": 1014,
+    "med": 1044,
+    "latencyAvg": 1003748,
+    "latencyMed": 957896,
+    "samples": 1000
   },
   {
     "name": "Create group & welcome",
-    "avg": 142,
-    "med": 145,
-    "latencyAvg": 7270762,
-    "latencyMed": 6885125,
+    "avg": 195,
+    "med": 198,
+    "latencyAvg": 5228770,
+    "latencyMed": 5044771,
     "samples": 1000
   }
 ]

--- a/bench/results/bench.json
+++ b/bench/results/bench.json
@@ -1,81 +1,82 @@
 [
   {
     "name": "Add 200 group members",
-    "avg": 2,
-    "med": 2,
-    "latencyAvg": 632549929,
-    "latencyMed": 629925250,
+    "avg": 7,
+    "med": 7,
+    "latencyAvg": 139315646,
+    "latencyMed": 139520979,
     "samples": 10
   },
   {
     "name": "Join group",
-    "avg": 3,
-    "med": 3,
-    "latencyAvg": 312978754,
-    "latencyMed": 306101625,
-    "samples": 10
+    "avg": 12,
+    "med": 12,
+    "latencyAvg": 81338545,
+    "latencyMed": 81279875,
+    "samples": 13
   },
   {
     "name": "Create empty commit",
     "avg": 10,
     "med": 10,
-    "latencyAvg": 98693974,
-    "latencyMed": 98253125,
+    "latencyAvg": 96935129,
+    "latencyMed": 97030583,
     "samples": 11
   },
   {
     "name": "Process empty commit",
-    "avg": null,
-    "med": null,
-    "latencyAvg": null,
-    "latencyMed": null
+    "avg": 16,
+    "med": 16,
+    "latencyAvg": 62650049,
+    "latencyMed": 62573354,
+    "samples": 16
   },
   {
     "name": "Send application message",
-    "avg": 2241,
-    "med": 2285,
-    "latencyAvg": 450253,
-    "latencyMed": 437625,
-    "samples": 2222
+    "avg": 1875,
+    "med": 1918,
+    "latencyAvg": 539548,
+    "latencyMed": 521292,
+    "samples": 1854
   },
   {
     "name": "Receive application message",
-    "avg": 738,
-    "med": 748,
-    "latencyAvg": 1359081,
-    "latencyMed": 1336063,
-    "samples": 736
+    "avg": 3373,
+    "med": 3461,
+    "latencyAvg": 302305,
+    "latencyMed": 288959,
+    "samples": 3309
   },
   {
     "name": "Add member",
-    "avg": 20,
-    "med": 20,
-    "latencyAvg": 49481619,
-    "latencyMed": 49014708,
+    "avg": 21,
+    "med": 21,
+    "latencyAvg": 48666109,
+    "latencyMed": 48168417,
     "samples": 21
   },
   {
     "name": "Receive add member commit",
     "avg": 23,
     "med": 23,
-    "latencyAvg": 44507442,
-    "latencyMed": 43602167,
-    "samples": 23
+    "latencyAvg": 43313995,
+    "latencyMed": 43325500,
+    "samples": 24
   },
   {
     "name": "Remove member",
     "avg": 22,
     "med": 22,
-    "latencyAvg": 45489449,
-    "latencyMed": 45515021,
+    "latencyAvg": 46421663,
+    "latencyMed": 46472396,
     "samples": 22
   },
   {
     "name": "Receive remove member commit",
-    "avg": 25,
-    "med": 25,
-    "latencyAvg": 40857472,
-    "latencyMed": 40570208,
+    "avg": 24,
+    "med": 24,
+    "latencyAvg": 41022570,
+    "latencyMed": 40875542,
     "samples": 25
   }
 ]


### PR DESCRIPTION
Turns out SubtleCrypto is a lot faster than noble and this library does A LOT of signature verification so it really matters.