### PR TITLE
Do not save encryptionSecret and epoch secrets after initializing epoch

### DIFF
--- a/src/createCommit.ts
+++ b/src/createCommit.ts
@@ -208,11 +208,7 @@ export async function createCommit(context: MLSContext, options?: CreateCommitOp
   const newState: ClientState = {
     groupContext: updatedGroupContext,
     ratchetTree: tree,
-    secretTree: await createSecretTree(
-      leafWidth(tree.length),
-      epochSecrets.keySchedule.encryptionSecret,
-      cipherSuite.kdf,
-    ),
+    secretTree: await createSecretTree(leafWidth(tree.length), epochSecrets.encryptionSecret, cipherSuite.kdf),
     keySchedule: epochSecrets.keySchedule,
     privatePath: privateKeys,
     unappliedProposals: {},
@@ -599,7 +595,7 @@ export async function joinGroupExternal(
   const state: ClientState = {
     ratchetTree: newTree,
     groupContext: groupContext,
-    secretTree: await createSecretTree(leafWidth(newTree.length), epochSecrets.keySchedule.encryptionSecret, cs.kdf),
+    secretTree: await createSecretTree(leafWidth(newTree.length), epochSecrets.encryptionSecret, cs.kdf),
     privatePath: privateKeyPath,
     confirmationTag,
     historicalReceiverData: new Map(),

--- a/src/processMessages.ts
+++ b/src/processMessages.ts
@@ -283,7 +283,7 @@ async function processCommit(
 
   if (!confirmationTagValid) throw new CryptoVerificationError("Could not verify confirmation tag")
 
-  const secretTree = await createSecretTree(leafWidth(tree.length), epochSecrets.keySchedule.encryptionSecret, cs.kdf)
+  const secretTree = await createSecretTree(leafWidth(tree.length), epochSecrets.encryptionSecret, cs.kdf)
 
   const suspendedPendingReinit = result.additionalResult.kind === "reinit" ? result.additionalResult.reinit : undefined
 

--- a/test/test-vectors/keySchedule.test.ts
+++ b/test/test-vectors/keySchedule.test.ts
@@ -41,7 +41,7 @@ async function testKeySchedule(
       // Verify that group context matches the provided group_context value
       expect(encodeGroupContext(gc)).toStrictEqual(hexToBytes(epoch.group_context))
 
-      const { keySchedule, joinerSecret, welcomeSecret } = await initializeEpoch(
+      const { keySchedule, joinerSecret, welcomeSecret, encryptionSecret } = await initializeEpoch(
         initSecret,
         hexToBytes(epoch.commit_secret),
         gc,
@@ -53,7 +53,7 @@ async function testKeySchedule(
       expect(welcomeSecret).toStrictEqual(hexToBytes(epoch.welcome_secret))
       expect(keySchedule.initSecret).toStrictEqual(hexToBytes(epoch.init_secret))
       expect(keySchedule.senderDataSecret).toStrictEqual(hexToBytes(epoch.sender_data_secret))
-      expect(keySchedule.encryptionSecret).toStrictEqual(hexToBytes(epoch.encryption_secret))
+      expect(encryptionSecret).toStrictEqual(hexToBytes(epoch.encryption_secret))
       expect(keySchedule.exporterSecret).toStrictEqual(hexToBytes(epoch.exporter_secret))
       expect(keySchedule.externalSecret).toStrictEqual(hexToBytes(epoch.external_secret))
       expect(keySchedule.confirmationKey).toStrictEqual(hexToBytes(epoch.confirmation_key))


### PR DESCRIPTION
In accordance with the spec:

> For example, suppose a group member encrypts or (successfully) decrypts an application message using the j-th key and nonce in the ratchet of leaf node L in some epoch n. Then, for that member, at least the following values have been consumed and MUST be deleted:
the commit_secret, joiner_secret, epoch_secret, and encryption_secret of that epoch n as well as the init_secret of the previous epoch n-1,