### PR TITLE
feat: expose sender leaf index in commit callbacks

### DIFF
--- a/src/incomingMessageAction.ts
+++ b/src/incomingMessageAction.ts
@@ -1,9 +1,12 @@
 import { ProposalWithSender } from "./unappliedProposals.js"
+import type { LeafIndex } from "./treemath.js"
 
 export type IncomingMessageAction = "accept" | "reject"
 
 export type IncomingMessageCallback = (
-  incoming: { kind: "commit"; proposals: ProposalWithSender[] } | { kind: "proposal"; proposal: ProposalWithSender },
+  incoming:
+    | { kind: "commit"; senderLeafIndex: LeafIndex | undefined; proposals: ProposalWithSender[] }
+    | { kind: "proposal"; proposal: ProposalWithSender },
 ) => IncomingMessageAction
 
 export const acceptAll: IncomingMessageCallback = () => "accept"

--- a/src/processMessages.ts
+++ b/src/processMessages.ts
@@ -201,7 +201,7 @@ async function processCommit(
 
   const result = await applyProposals(state, content.content.commit.proposals, senderLeafIndex, pskSearch, false, cs)
 
-  const action = callback({ kind: "commit", proposals: result.allProposals })
+  const action = callback({ kind: "commit", senderLeafIndex, proposals: result.allProposals })
 
   if (action === "reject") {
     return { newState: state, actionTaken: action }


### PR DESCRIPTION
Add senderLeafIndex to the IncomingMessageCallback interface for commit messages, allowing callbacks to access the sender's leaf index for identity verification or processing logic. This enhances the ability to handle commit messages with sender-specific information.

resolves: #192 