### PR TITLE
Add support for app_data_dictionary + app_data_update from draft-ietf-mls-extensions-09

### DIFF
--- a/api/ts-mls.api.md
+++ b/api/ts-mls.api.md
@@ -16,6 +16,37 @@ export interface Add {
 // @public (undocumented)
 export type AeadAlgorithm = "AES128GCM" | "CHACHA20POLY1305" | "AES256GCM";
 
+// @public
+export type AppDataDictionary = ComponentData[];
+
+// @public
+export const appDataDictionaryExtensionType = 6;
+
+// @public
+export type AppDataUpdate = {
+    componentId: number;
+    operation: "update";
+    update: Uint8Array;
+} | {
+    componentId: number;
+    operation: "remove";
+};
+
+// @public
+export type AppDataUpdateCallback = (componentId: number, currentData: Uint8Array | undefined, updates: Uint8Array[]) => Uint8Array | undefined;
+
+// @public (undocumented)
+export type AppDataUpdateOperationName = keyof typeof appDataUpdateOperations;
+
+// @public
+export const appDataUpdateOperations: {
+    readonly update: 1;
+    readonly remove: 2;
+};
+
+// @public
+export const appDataUpdateProposalType = 8;
+
 // @public (undocumented)
 export interface AuthenticationService {
     // (undocumented)
@@ -118,6 +149,8 @@ export const ciphersuites: {
 // @public (undocumented)
 export interface ClientConfig {
     // (undocumented)
+    appDataUpdateCallback: AppDataUpdateCallback;
+    // (undocumented)
     keyPackageEqualityConfig: KeyPackageEqualityConfig;
     // (undocumented)
     keyRetentionConfig: KeyRetentionConfig;
@@ -147,6 +180,14 @@ export interface Commit {
     path: UpdatePath | undefined;
     // (undocumented)
     proposals: ProposalOrRef[];
+}
+
+// @public
+export interface ComponentData {
+    // (undocumented)
+    componentId: number;
+    // (undocumented)
+    data: Uint8Array;
 }
 
 // @public (undocumented)
@@ -325,6 +366,9 @@ export function decode<T>(dec: Decoder<T>, t: Uint8Array, maxInputSize?: number)
 
 // @public (undocumented)
 export type Decoder<T> = (b: Uint8Array, offset: number) => [T, number] | undefined;
+
+// @public
+export const defaultAppDataUpdateCallback: AppDataUpdateCallback;
 
 // @public (undocumented)
 export function defaultCapabilities(): Capabilities;
@@ -609,6 +653,9 @@ export interface GenerationSecret {
     unusedGenerations: Record<number, Uint8Array>;
 }
 
+// @public
+export function getAppDataDictionary(extensions: GroupContextExtension[]): AppDataDictionary | undefined;
+
 // @public (undocumented)
 export function getCiphersuiteImpl(cs: CiphersuiteName, provider?: CryptoProvider): Promise<CiphersuiteImpl>;
 
@@ -816,6 +863,12 @@ export type IncomingMessageCallback = (incoming: {
 export class InternalError extends MlsError {
     constructor(message: string);
 }
+
+// @public (undocumented)
+export function isAppDataUpdateProposal(p: Proposal): p is ProposalAppDataUpdate;
+
+// @public (undocumented)
+export function isCustomProposal(p: Proposal): p is ProposalCustom;
 
 // @public (undocumented)
 export function isDefaultCredential(c: Credential_2): c is DefaultCredential;
@@ -1059,6 +1112,9 @@ export interface LifetimeConfig {
     validateLifetimeOnReceive: boolean;
 }
 
+// @public
+export function makeAppDataDictionaryExtension(dictionary: AppDataDictionary): CustomExtension;
+
 // @public (undocumented)
 export function makeCustomExtension(extension: {
     extensionType: number;
@@ -1292,7 +1348,7 @@ export function processPublicMessage(params: {
 }): Promise<NewStateWithActionTaken>;
 
 // @public (undocumented)
-export type Proposal = DefaultProposal | ProposalCustom;
+export type Proposal = DefaultProposal | ProposalAppDataUpdate | ProposalCustom;
 
 // @public (undocumented)
 export interface ProposalAdd {
@@ -1300,6 +1356,14 @@ export interface ProposalAdd {
     add: Add;
     // (undocumented)
     proposalType: typeof defaultProposalTypes.add;
+}
+
+// @public
+export interface ProposalAppDataUpdate {
+    // (undocumented)
+    appDataUpdate: AppDataUpdate;
+    // (undocumented)
+    proposalType: typeof appDataUpdateProposalType;
 }
 
 // @public (undocumented)

--- a/docs/18-custom-proposals.md
+++ b/docs/18-custom-proposals.md
@@ -29,7 +29,7 @@ import {
   createProposal,
   createApplicationMessage,
   processMessage,
-  isDefaultProposal,
+  isCustomProposal,
   processPrivateMessage,
   Credential,
   defaultCredentialTypes,
@@ -144,7 +144,7 @@ const processProposalResult = await processMessage({
   state: aliceGroup,
   message: createProposalResult.message,
   callback: (p) => {
-    if (p.kind !== "proposal" || isDefaultProposal(p.proposal.proposal)) throw new Error("Expected custom proposal")
+    if (p.kind !== "proposal" || !isCustomProposal(p.proposal.proposal)) throw new Error("Expected custom proposal")
 
     // Inspect the custom proposal
     if (p.proposal.proposal.proposalData) {
@@ -180,7 +180,7 @@ const processCommitResult = await processMessage({
     // Bob can see the custom proposal in the commit
     const proposals = p.proposals.map((p) => p.proposal)
 
-    if (proposals[0] && !isDefaultProposal(proposals[0]) && proposals[0].proposalData) {
+    if (proposals[0] && isCustomProposal(proposals[0]) && proposals[0].proposalData) {
       const data = new TextDecoder().decode(proposals[0].proposalData)
     }
 

--- a/docs/20-app-data-updates.md
+++ b/docs/20-app-data-updates.md
@@ -1,0 +1,162 @@
+# Application Data Updates
+
+This scenario demonstrates the `app_data_dictionary` GroupContext extension and the `app_data_update` proposal from [draft-ietf-mls-extensions-09](https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions-09). Together they let applications store opaque per-component data in the GroupContext — agreed on by all members and automatically distributed to new joiners — and update individual components without resending the whole extension set or requiring an UpdatePath.
+
+## Steps Covered
+
+1. **Setup Capabilities**: Members advertise the `app_data_dictionary` extension and `app_data_update` proposal types.
+2. **Group Creation**: Alice creates a group whose GroupContext carries an initial dictionary.
+3. **Joining**: Bob joins and receives the dictionary as part of the GroupContext.
+4. **Update Commit**: Alice commits an `app_data_update` proposal that replaces one component's data.
+5. **Process Commit**: Bob processes the commit; both members converge on the new dictionary.
+
+## Key Concepts
+
+- **AppDataDictionary**: A list of `ComponentData` entries, each associating opaque application data with a `componentId` (a `uint16`). Entries are sorted by componentId with at most one entry per componentId.
+- **AppDataUpdate Proposal**: Updates or removes a single component's entry. Because the proposal is applied while forming the new GroupContext, the updated dictionary is folded into the confirmed transcript, the key schedule, and the confirmation tag.
+- **Application Logic**: The update payloads are opaque to MLS. The `appDataUpdateCallback` in the `ClientConfig` decides how update payloads transform a component's data. The default treats each update as a full replacement (the last update for a component wins). All members must use the same logic to converge.
+- **Capabilities**: Members must advertise extension type `6` and proposal type `8` in their capabilities.
+
+---
+
+```typescript
+import {
+  createGroup,
+  joinGroup,
+  createCommit,
+  processMessage,
+  Credential,
+  defaultCredentialTypes,
+  getCiphersuiteImpl,
+  generateKeyPackage,
+  Capabilities,
+  protocolVersions,
+  ciphersuites,
+  defaultProposalTypes,
+  unsafeTestingAuthenticationService,
+  appDataDictionaryExtensionType,
+  appDataUpdateProposalType,
+  makeAppDataDictionaryExtension,
+  getAppDataDictionary,
+  ProposalAppDataUpdate,
+  zeroOutUint8Array,
+} from "ts-mls"
+
+// Setup ciphersuite
+const impl = await getCiphersuiteImpl("MLS_256_XWING_AES256GCM_SHA512_Ed25519")
+const context = { cipherSuite: impl, authService: unsafeTestingAuthenticationService }
+
+// Application components use ids in the private use range (0x8000 - 0xFFFF)
+const componentId = 0x8001
+
+// Members must advertise the app_data_dictionary extension and
+// the app_data_update proposal in their capabilities
+const capabilities: Capabilities = {
+  extensions: [appDataDictionaryExtensionType],
+  credentials: [defaultCredentialTypes.basic],
+  proposals: [appDataUpdateProposalType],
+  versions: [protocolVersions.mls10],
+  ciphersuites: [ciphersuites["MLS_256_XWING_AES256GCM_SHA512_Ed25519"]],
+}
+
+// Setup Alice's credential
+const aliceCredential: Credential = {
+  credentialType: defaultCredentialTypes.basic,
+  identity: new TextEncoder().encode("alice"),
+}
+const alice = await generateKeyPackage({
+  credential: aliceCredential,
+  capabilities,
+  cipherSuite: impl,
+})
+
+const groupId = new TextEncoder().encode("group1")
+
+// Alice creates the group with an initial dictionary in the GroupContext
+let aliceGroup = await createGroup({
+  context,
+  groupId,
+  keyPackage: alice.publicPackage,
+  privateKeyPackage: alice.privatePackage,
+  extensions: [makeAppDataDictionaryExtension([{ componentId, data: new TextEncoder().encode("initial state") }])],
+})
+
+// Setup Bob's credential
+const bobCredential: Credential = {
+  credentialType: defaultCredentialTypes.basic,
+  identity: new TextEncoder().encode("bob"),
+}
+const bob = await generateKeyPackage({
+  credential: bobCredential,
+  capabilities,
+  cipherSuite: impl,
+})
+
+// Alice adds Bob to the group
+const addBobCommitResult = await createCommit({
+  context,
+  state: aliceGroup,
+  extraProposals: [
+    {
+      proposalType: defaultProposalTypes.add,
+      add: {
+        keyPackage: bob.publicPackage,
+      },
+    },
+  ],
+})
+
+aliceGroup = addBobCommitResult.newState
+addBobCommitResult.consumed.forEach(zeroOutUint8Array)
+
+// Bob joins the group and receives the dictionary as part of the GroupContext
+let bobGroup = await joinGroup({
+  context,
+  welcome: addBobCommitResult.welcome!.welcome,
+  keyPackage: bob.publicPackage,
+  privateKeys: bob.privatePackage,
+  ratchetTree: aliceGroup.ratchetTree,
+})
+
+// Alice updates the component's data with an app_data_update proposal
+const appDataUpdate: ProposalAppDataUpdate = {
+  proposalType: appDataUpdateProposalType,
+  appDataUpdate: {
+    componentId,
+    operation: "update",
+    update: new TextEncoder().encode("updated state"),
+  },
+}
+
+const updateCommitResult = await createCommit({
+  context,
+  state: aliceGroup,
+  extraProposals: [appDataUpdate],
+})
+
+aliceGroup = updateCommitResult.newState
+updateCommitResult.consumed.forEach(zeroOutUint8Array)
+
+// Bob processes the commit and converges on the same dictionary
+const processCommitResult = await processMessage({
+  context,
+  state: bobGroup,
+  message: updateCommitResult.commit,
+})
+
+bobGroup = processCommitResult.newState
+processCommitResult.consumed.forEach(zeroOutUint8Array)
+
+// Both members now see the updated dictionary in their GroupContext
+const aliceDictionary = getAppDataDictionary(aliceGroup.groupContext.extensions)
+const bobDictionary = getAppDataDictionary(bobGroup.groupContext.extensions)
+```
+
+## Notes
+
+- **Component Id Range**: Use ids in the private use range (0x8000 - 0xFFFF) for application-defined components, like the application-specific proposal and extension type ranges.
+- **Remove Operation**: An `app_data_update` proposal with `operation: "remove"` deletes a component's entry. Removing a component that has no entry is invalid.
+- **Multiple Updates**: A commit may contain several update proposals for the same component; they are passed to the `appDataUpdateCallback` in commit order. For a given component, a commit must contain either a single remove or one or more updates — never both.
+- **Custom Application Logic**: Override `appDataUpdateCallback` in the `ClientConfig` to implement diff-based or merge semantics for update payloads. Every member must use the same logic, since the resulting dictionary feeds the confirmation tag.
+- **No UpdatePath Required**: Unlike `group_context_extensions` proposals, `app_data_update` proposals do not force an UpdatePath, making dictionary updates cheap.
+- **Interaction with GroupContextExtensions**: A commit may combine a `group_context_extensions` proposal with `app_data_update` proposals, but the GCE proposal must come first. When the group's required capabilities include the `app_data_update` proposal type, a GCE proposal must not add, remove, or modify the `app_data_dictionary` extension.

--- a/src/appDataDictionary.ts
+++ b/src/appDataDictionary.ts
@@ -1,0 +1,85 @@
+import { uint16Decoder, uint16Encoder } from "./codec/number.js"
+import { decode, Decoder, mapDecoderOption, mapDecoders } from "./codec/tlsDecoder.js"
+import { contramapBufferEncoders, encode, Encoder } from "./codec/tlsEncoder.js"
+import { varLenDataDecoder, varLenDataEncoder, varLenTypeDecoder, varLenTypeEncoder } from "./codec/variableLength.js"
+import { CustomExtension, GroupContextExtension, makeCustomExtension } from "./extension.js"
+import { UsageError, ValidationError } from "./mlsError.js"
+
+/**
+ * The `app_data_dictionary` extension type defined in draft-ietf-mls-extensions-09.
+ *
+ * @public
+ */
+export const appDataDictionaryExtensionType = 6
+
+/**
+ * A single entry in an {@link AppDataDictionary}, associating opaque application
+ * data with a component id.
+ *
+ * @public
+ */
+export interface ComponentData {
+  componentId: number
+  data: Uint8Array
+}
+
+export const componentDataEncoder: Encoder<ComponentData> = contramapBufferEncoders(
+  [uint16Encoder, varLenDataEncoder],
+  (c) => [c.componentId, c.data] as const,
+)
+
+export const componentDataDecoder: Decoder<ComponentData> = mapDecoders(
+  [uint16Decoder, varLenDataDecoder],
+  (componentId, data) => ({ componentId, data }),
+)
+
+/**
+ * The content of the `app_data_dictionary` extension. Entries MUST be sorted by
+ * componentId and there MUST be at most one entry per componentId.
+ *
+ * @public
+ */
+export type AppDataDictionary = ComponentData[]
+
+export const appDataDictionaryEncoder: Encoder<AppDataDictionary> = varLenTypeEncoder(componentDataEncoder)
+
+export const appDataDictionaryDecoder: Decoder<AppDataDictionary> = mapDecoderOption(
+  varLenTypeDecoder(componentDataDecoder),
+  (entries) => (componentDataSortedAndUnique(entries) ? entries : undefined),
+)
+
+function componentDataSortedAndUnique(entries: ComponentData[]): boolean {
+  return entries.every((e, i) => i === 0 || entries[i - 1]!.componentId < e.componentId)
+}
+
+/**
+ * Creates an `app_data_dictionary` GroupContext extension carrying the given dictionary.
+ * The dictionary entries must be sorted by componentId with at most one entry per componentId.
+ *
+ * @public
+ */
+export function makeAppDataDictionaryExtension(dictionary: AppDataDictionary): CustomExtension {
+  if (!componentDataSortedAndUnique(dictionary))
+    throw new UsageError("AppDataDictionary entries must be sorted by componentId and unique")
+
+  return makeCustomExtension({
+    extensionType: appDataDictionaryExtensionType,
+    extensionData: encode(appDataDictionaryEncoder, dictionary),
+  })
+}
+
+/**
+ * Reads the {@link AppDataDictionary} carried in an extension list. Returns undefined
+ * if no `app_data_dictionary` extension is present.
+ *
+ * @public
+ */
+export function getAppDataDictionary(extensions: GroupContextExtension[]): AppDataDictionary | undefined {
+  const extension = extensions.find((e): e is CustomExtension => e.extensionType === appDataDictionaryExtensionType)
+  if (extension === undefined) return undefined
+
+  const dictionary = decode(appDataDictionaryDecoder, extension.extensionData)
+  if (dictionary === undefined) throw new ValidationError("Could not decode app_data_dictionary extension")
+
+  return dictionary
+}

--- a/src/appDataUpdate.ts
+++ b/src/appDataUpdate.ts
@@ -1,0 +1,155 @@
+import { uint16Decoder, uint16Encoder, uint8Decoder, uint8Encoder } from "./codec/number.js"
+import { Decoder, failDecoder, flatMapDecoder, mapDecoder, mapDecoders, succeedDecoder } from "./codec/tlsDecoder.js"
+import { contramapBufferEncoders, Encoder } from "./codec/tlsEncoder.js"
+import { varLenDataDecoder, varLenDataEncoder } from "./codec/variableLength.js"
+import {
+  appDataDictionaryExtensionType,
+  getAppDataDictionary,
+  makeAppDataDictionaryExtension,
+} from "./appDataDictionary.js"
+import { GroupContextExtension } from "./extension.js"
+import { ValidationError } from "./mlsError.js"
+
+/**
+ * The `app_data_update` proposal type defined in draft-ietf-mls-extensions-09.
+ *
+ * @public
+ */
+export const appDataUpdateProposalType = 8
+
+/**
+ * The AppDataUpdateOperation values defined in draft-ietf-mls-extensions-09.
+ *
+ * @public
+ */
+export const appDataUpdateOperations = {
+  update: 1,
+  remove: 2,
+} as const
+
+/** @public */
+export type AppDataUpdateOperationName = keyof typeof appDataUpdateOperations
+
+/**
+ * The content of an `app_data_update` proposal (draft-ietf-mls-extensions-09):
+ * either replaces the application data for a component or removes the component's
+ * entry from the `app_data_dictionary` GroupContext extension.
+ *
+ * @public
+ */
+export type AppDataUpdate =
+  | { componentId: number; operation: "update"; update: Uint8Array }
+  | { componentId: number; operation: "remove" }
+
+const appDataUpdateUpdateEncoder: Encoder<{ componentId: number; update: Uint8Array }> = contramapBufferEncoders(
+  [uint16Encoder, uint8Encoder, varLenDataEncoder],
+  (u) => [u.componentId, appDataUpdateOperations.update, u.update] as const,
+)
+
+const appDataUpdateRemoveEncoder: Encoder<{ componentId: number }> = contramapBufferEncoders(
+  [uint16Encoder, uint8Encoder],
+  (u) => [u.componentId, appDataUpdateOperations.remove] as const,
+)
+
+export const appDataUpdateEncoder: Encoder<AppDataUpdate> = (u) =>
+  u.operation === "update" ? appDataUpdateUpdateEncoder(u) : appDataUpdateRemoveEncoder(u)
+
+export const appDataUpdateDecoder: Decoder<AppDataUpdate> = flatMapDecoder(
+  mapDecoders([uint16Decoder, uint8Decoder], (componentId, operation) => ({ componentId, operation })),
+  ({ componentId, operation }): Decoder<AppDataUpdate> => {
+    switch (operation) {
+      case appDataUpdateOperations.update:
+        return mapDecoder(varLenDataDecoder, (update) => ({ componentId, operation: "update", update }))
+      case appDataUpdateOperations.remove:
+        return succeedDecoder({ componentId, operation: "remove" })
+      default:
+        return failDecoder()
+    }
+  },
+)
+
+/**
+ * The application logic that interprets the update payloads of `app_data_update`
+ * proposals for a component (draft-ietf-mls-extensions-09 Section 4.7).
+ *
+ * Receives the componentId, the current data stored for the component (or undefined
+ * if no entry exists) and the update payloads for the component in commit order.
+ * Returns the new data to store for the component, or undefined if the application
+ * considers the updates invalid, which invalidates the whole proposal list.
+ *
+ * @public
+ */
+export type AppDataUpdateCallback = (
+  componentId: number,
+  currentData: Uint8Array | undefined,
+  updates: Uint8Array[],
+) => Uint8Array | undefined
+
+/**
+ * The default {@link AppDataUpdateCallback}: each update payload fully replaces the
+ * component's data, so the last update for a component wins.
+ *
+ * @public
+ */
+export const defaultAppDataUpdateCallback: AppDataUpdateCallback = (_componentId, _currentData, updates) =>
+  updates.at(-1)
+
+/**
+ * Applies a list of AppDataUpdates (in commit order) to the `app_data_dictionary`
+ * extension contained in the given GroupContext extension list, per
+ * draft-ietf-mls-extensions-09 Section 4.7. Returns the new extension list.
+ */
+export function applyAppDataUpdates(
+  extensions: GroupContextExtension[],
+  updates: AppDataUpdate[],
+  callback: AppDataUpdateCallback,
+): GroupContextExtension[] {
+  const dictionary = [...(getAppDataDictionary(extensions) ?? [])]
+
+  const updatesByComponent = new Map<number, AppDataUpdate[]>()
+  for (const update of updates) {
+    const componentUpdates = updatesByComponent.get(update.componentId) ?? []
+    componentUpdates.push(update)
+    updatesByComponent.set(update.componentId, componentUpdates)
+  }
+
+  for (const [componentId, componentUpdates] of updatesByComponent) {
+    const entryIndex = dictionary.findIndex((e) => e.componentId === componentId)
+    const containsRemove = componentUpdates.some((u) => u.operation === "remove")
+
+    if (containsRemove) {
+      if (componentUpdates.length > 1)
+        throw new ValidationError(
+          "Commit cannot contain multiple AppDataUpdate proposals that remove state for the same component or both update and remove state for the same component",
+        )
+
+      if (entryIndex === -1)
+        throw new ValidationError("AppDataUpdate cannot remove state for a component that has no state present")
+
+      dictionary.splice(entryIndex, 1)
+    } else {
+      const newData = callback(
+        componentId,
+        entryIndex === -1 ? undefined : dictionary[entryIndex]!.data,
+        componentUpdates.flatMap((u) => (u.operation === "update" ? [u.update] : [])),
+      )
+
+      if (newData === undefined)
+        throw new ValidationError("Application logic considered the AppDataUpdate proposals for a component invalid")
+
+      if (entryIndex === -1) {
+        const insertAt = dictionary.findIndex((e) => e.componentId > componentId)
+        dictionary.splice(insertAt === -1 ? dictionary.length : insertAt, 0, { componentId, data: newData })
+      } else {
+        dictionary[entryIndex] = { componentId, data: newData }
+      }
+    }
+  }
+
+  const newExtension = makeAppDataDictionaryExtension(dictionary)
+  const extensionIndex = extensions.findIndex((e) => e.extensionType === appDataDictionaryExtensionType)
+
+  return extensionIndex === -1
+    ? [...extensions, newExtension]
+    : extensions.map((e, i) => (i === extensionIndex ? newExtension : e))
+}

--- a/src/clientConfig.ts
+++ b/src/clientConfig.ts
@@ -1,3 +1,4 @@
+import { AppDataUpdateCallback, defaultAppDataUpdateCallback } from "./appDataUpdate.js"
 import { defaultKeyPackageEqualityConfig, KeyPackageEqualityConfig } from "./keyPackageEqualityConfig.js"
 import { defaultKeyRetentionConfig, KeyRetentionConfig } from "./keyRetentionConfig.js"
 import { defaultLifetimeConfig, LifetimeConfig } from "./lifetimeConfig.js"
@@ -9,6 +10,7 @@ export interface ClientConfig {
   lifetimeConfig: LifetimeConfig
   keyPackageEqualityConfig: KeyPackageEqualityConfig
   paddingConfig: PaddingConfig
+  appDataUpdateCallback: AppDataUpdateCallback
 }
 
 export const defaultClientConfig: ClientConfig = {
@@ -16,4 +18,5 @@ export const defaultClientConfig: ClientConfig = {
   lifetimeConfig: defaultLifetimeConfig,
   keyPackageEqualityConfig: defaultKeyPackageEqualityConfig,
   paddingConfig: defaultPaddingConfig,
+  appDataUpdateCallback: defaultAppDataUpdateCallback,
 }

--- a/src/clientConfig.ts
+++ b/src/clientConfig.ts
@@ -20,3 +20,11 @@ export const defaultClientConfig: ClientConfig = {
   paddingConfig: defaultPaddingConfig,
   appDataUpdateCallback: defaultAppDataUpdateCallback,
 }
+
+/**
+ * Fills in defaults for any missing ClientConfig fields, so callers that
+ * constructed a config before a field existed keep working at runtime.
+ */
+export function resolveClientConfig(clientConfig: ClientConfig | undefined): ClientConfig {
+  return clientConfig === undefined ? defaultClientConfig : { ...defaultClientConfig, ...clientConfig }
+}

--- a/src/clientState.ts
+++ b/src/clientState.ts
@@ -54,6 +54,7 @@ import {
 import { WireformatName, wireformats } from "./wireformat.js"
 import { ProposalOrRef, proposalOrRefTypes } from "./proposalOrRefType.js"
 import {
+  isAppDataUpdateProposal,
   isDefaultProposal,
   Proposal,
   ProposalAdd,
@@ -66,6 +67,8 @@ import {
   Reinit,
   Remove,
 } from "./proposal.js"
+import { AppDataUpdate, applyAppDataUpdates, appDataUpdateProposalType } from "./appDataUpdate.js"
+import { appDataDictionaryExtensionType } from "./appDataDictionary.js"
 import { defaultProposalTypes } from "./defaultProposalType.js"
 import { defaultExtensionTypes } from "./defaultExtensionType.js"
 import { pathToRoot } from "./pathSecrets.js"
@@ -740,6 +743,56 @@ function validateRemove(remove: Remove, tree: RatchetTree): MlsError | undefined
     return new ValidationError("Tried to remove empty leaf node")
 }
 
+function extractAppDataUpdates(allProposals: ProposalWithSender[]): AppDataUpdate[] {
+  return allProposals.flatMap(({ proposal }) => (isAppDataUpdateProposal(proposal) ? [proposal.appDataUpdate] : []))
+}
+
+function validateAppDataUpdateProposals(
+  allProposals: ProposalWithSender[],
+  gceExtensions: GroupContextExtension[] | undefined,
+  currentExtensions: GroupContextExtension[],
+): ValidationError | undefined {
+  const proposalTypes = allProposals.map(({ proposal }) => proposal.proposalType)
+  const firstAppDataUpdate = proposalTypes.indexOf(appDataUpdateProposalType)
+
+  // AppDataUpdate proposals are processed after all other proposals, so they must
+  // appear after a GroupContextExtensions proposal in the proposal list
+  if (firstAppDataUpdate !== -1) {
+    const lastGroupContextExtensions = proposalTypes.lastIndexOf(defaultProposalTypes.group_context_extensions)
+    if (lastGroupContextExtensions > firstAppDataUpdate)
+      return new ValidationError("AppDataUpdate proposals must appear after a GroupContextExtensions proposal")
+  }
+
+  // When required_capabilities includes the AppDataUpdate proposal type, a
+  // GroupContextExtensions proposal must not add, remove, or modify the
+  // app_data_dictionary extension
+  if (gceExtensions !== undefined) {
+    const requiredCapabilities = gceExtensions.find(
+      (e): e is ExtensionRequiredCapabilities => e.extensionType === defaultExtensionTypes.required_capabilities,
+    )
+
+    if (requiredCapabilities?.extensionData.proposalTypes.includes(appDataUpdateProposalType)) {
+      const currentDictionary = currentExtensions.find(
+        (e) => e.extensionType === appDataDictionaryExtensionType,
+      )?.extensionData
+      const proposedDictionary = gceExtensions.find(
+        (e) => e.extensionType === appDataDictionaryExtensionType,
+      )?.extensionData
+
+      const dictionaryUnchanged =
+        currentDictionary === undefined
+          ? proposedDictionary === undefined
+          : proposedDictionary !== undefined &&
+            constantTimeEqual(currentDictionary as Uint8Array, proposedDictionary as Uint8Array)
+
+      if (!dictionaryUnchanged)
+        return new ValidationError(
+          "GroupContextExtensions proposal cannot modify the app_data_dictionary extension when required capabilities include the AppDataUpdate proposal type",
+        )
+    }
+  }
+}
+
 export interface ApplyProposalsResult {
   pskSecret: Uint8Array
   pskIds: PskId[]
@@ -753,7 +806,12 @@ export interface ApplyProposalsResult {
 
 type ApplyProposalsData =
   | { kind: "memberCommit"; addedLeafNodes: [LeafIndex, KeyPackage][]; extensions: GroupContextExtension[] | undefined }
-  | { kind: "externalCommit"; externalInitSecret: Uint8Array; newMemberLeafIndex: LeafIndex }
+  | {
+      kind: "externalCommit"
+      externalInitSecret: Uint8Array
+      newMemberLeafIndex: LeafIndex
+      extensions: GroupContextExtension[] | undefined
+    }
   | { kind: "reinit"; reinit: Reinit }
 
 export async function applyProposals(
@@ -825,6 +883,19 @@ export async function applyProposals(
 
     const newExtensions = flattenExtensions(grouped[defaultProposalTypes.group_context_extensions])
 
+    throwIfDefined(validateAppDataUpdateProposals(allProposals, newExtensions, state.groupContext.extensions))
+
+    const appDataUpdates = extractAppDataUpdates(allProposals)
+
+    const updatedExtensions =
+      appDataUpdates.length > 0
+        ? applyAppDataUpdates(
+            newExtensions ?? state.groupContext.extensions,
+            appDataUpdates,
+            clientConfig.appDataUpdateCallback,
+          )
+        : newExtensions
+
     const addedLeafNodes = await applyTreeMutations(
       mutableTree,
       grouped,
@@ -848,7 +919,12 @@ export async function applyProposals(
       allProposals.length === 0 ||
       allProposals.some(({ proposal }) => {
         const t = proposal.proposalType
-        return t !== defaultProposalTypes.add && t !== defaultProposalTypes.psk && t !== defaultProposalTypes.reinit
+        return (
+          t !== defaultProposalTypes.add &&
+          t !== defaultProposalTypes.psk &&
+          t !== defaultProposalTypes.reinit &&
+          t !== appDataUpdateProposalType
+        )
       })
 
     const updatedLeaves: LeafIndex[] = [
@@ -864,7 +940,7 @@ export async function applyProposals(
       additionalResult: {
         kind: "memberCommit" as const,
         addedLeafNodes,
-        extensions: newExtensions,
+        extensions: updatedExtensions,
       },
       pskIds,
       needsUpdatePath,
@@ -875,6 +951,15 @@ export async function applyProposals(
     }
   } else {
     throwIfDefined(validateExternalInit(grouped))
+
+    throwIfDefined(validateAppDataUpdateProposals(allProposals, undefined, state.groupContext.extensions))
+
+    const appDataUpdates = extractAppDataUpdates(allProposals)
+
+    const updatedExtensions =
+      appDataUpdates.length > 0
+        ? applyAppDataUpdates(state.groupContext.extensions, appDataUpdates, clientConfig.appDataUpdateCallback)
+        : undefined
 
     grouped[defaultProposalTypes.remove].forEach(({ proposal }) => {
       removeLeafNodeMutable(mutableTree, toLeafIndex(proposal.remove.removed))
@@ -911,6 +996,7 @@ export async function applyProposals(
         kind: "externalCommit",
         externalInitSecret,
         newMemberLeafIndex: nodeToLeafIndex(findBlankLeafNodeIndexOrExtend(mutableTree)),
+        extensions: updatedExtensions,
       },
       selfRemoved: false,
       allProposals,

--- a/src/clientState.ts
+++ b/src/clientState.ts
@@ -119,7 +119,7 @@ import { decryptGroupInfo, decryptGroupSecrets, Welcome } from "./welcome.js"
 import { AuthenticationService } from "./authenticationService.js"
 import { LifetimeConfig } from "./lifetimeConfig.js"
 import { KeyPackageEqualityConfig } from "./keyPackageEqualityConfig.js"
-import { ClientConfig, defaultClientConfig } from "./clientConfig.js"
+import { ClientConfig, resolveClientConfig } from "./clientConfig.js"
 import { Encoder, contramapBufferEncoders, encode } from "./codec/tlsEncoder.js"
 
 import {
@@ -765,13 +765,19 @@ function validateAppDataUpdateProposals(
 
   // When required_capabilities includes the AppDataUpdate proposal type, a
   // GroupContextExtensions proposal must not add, remove, or modify the
-  // app_data_dictionary extension
+  // app_data_dictionary extension. The dictionary is protected when either the
+  // current group context or the proposed extensions require the AppDataUpdate
+  // proposal type, so the protection cannot be bypassed by simultaneously
+  // dropping the capability and modifying the dictionary
   if (gceExtensions !== undefined) {
-    const requiredCapabilities = gceExtensions.find(
-      (e): e is ExtensionRequiredCapabilities => e.extensionType === defaultExtensionTypes.required_capabilities,
-    )
+    const requiresAppDataUpdate = (extensions: GroupContextExtension[]) =>
+      extensions
+        .find(
+          (e): e is ExtensionRequiredCapabilities => e.extensionType === defaultExtensionTypes.required_capabilities,
+        )
+        ?.extensionData.proposalTypes.includes(appDataUpdateProposalType) === true
 
-    if (requiredCapabilities?.extensionData.proposalTypes.includes(appDataUpdateProposalType)) {
+    if (requiresAppDataUpdate(currentExtensions) || requiresAppDataUpdate(gceExtensions)) {
       const currentDictionary = currentExtensions.find(
         (e) => e.extensionType === appDataDictionaryExtensionType,
       )?.extensionData
@@ -1081,7 +1087,7 @@ export async function joinGroupInternal(params: {
   const pskSearch = makePskIndex(params.resumingFromState, context.externalPsks ?? {})
   const authService = context.authService
   const cs = context.cipherSuite
-  const clientConfig = context.clientConfig ?? defaultClientConfig
+  const clientConfig = resolveClientConfig(context.clientConfig)
 
   const ratchetTree = params.ratchetTree
   const resumingFromState = params.resumingFromState

--- a/src/createCommit.ts
+++ b/src/createCommit.ts
@@ -64,7 +64,7 @@ import { createUpdatePath, PathSecret, firstCommonAncestor, UpdatePath, firstMat
 import { base64ToBytes, zeroOutUint8Array } from "./util/byteArray.js"
 import { Welcome, encryptGroupInfo, EncryptedGroupSecrets, encryptGroupSecrets } from "./welcome.js"
 import { CryptoVerificationError, InternalError, UsageError, ValidationError } from "./mlsError.js"
-import { ClientConfig, defaultClientConfig } from "./clientConfig.js"
+import { ClientConfig, resolveClientConfig } from "./clientConfig.js"
 import { ExtensionExternalPub, extensionsSupportedByCapabilities, GroupInfoExtension } from "./extension.js"
 import { encode } from "./codec/tlsEncoder.js"
 import { PublicMessage } from "./publicMessage.js"
@@ -100,7 +100,7 @@ export async function createCommitInternal(
   const { context, state, resumingFromState: pskState, ...options } = params
   const { cipherSuite } = context
   const pskIndex = makePskIndex(pskState ?? state, context.externalPsks ?? {})
-  const clientConfig = context.clientConfig ?? defaultClientConfig
+  const clientConfig = resolveClientConfig(context.clientConfig)
   const {
     wireAsPublicMessage = false,
     extraProposals = [],
@@ -557,7 +557,7 @@ export async function joinGroupExternal(params: {
 
   const authService = context.authService
   const cs = context.cipherSuite
-  const clientConfig = context.clientConfig ?? defaultClientConfig
+  const clientConfig = resolveClientConfig(context.clientConfig)
 
   const tree = params.tree
   const authenticatedData = params.authenticatedData ?? new Uint8Array()

--- a/src/createMessage.ts
+++ b/src/createMessage.ts
@@ -11,7 +11,7 @@ import { addUnappliedProposal } from "./unappliedProposals.js"
 import { protocolVersions } from "./protocolVersion.js"
 import { wireformats } from "./wireformat.js"
 import type { MlsContext } from "./mlsContext.js"
-import { defaultClientConfig } from "./clientConfig.js"
+import { resolveClientConfig } from "./clientConfig.js"
 import { InternalError } from "./mlsError.js"
 
 /** @public */
@@ -33,7 +33,7 @@ export async function createProposal(params: {
   const state = params.state
   const cs = context.cipherSuite
   const ad = params.authenticatedData ?? new Uint8Array()
-  const clientConfig = context.clientConfig ?? defaultClientConfig
+  const clientConfig = resolveClientConfig(context.clientConfig)
 
   const publicMessage = params.wireAsPublicMessage ?? false
   const proposal = params.proposal
@@ -170,7 +170,7 @@ export async function createApplicationMessage(params: {
   const state = params.state
   const cs = context.cipherSuite
   const ad = params.authenticatedData ?? new Uint8Array()
-  const clientConfig = context.clientConfig ?? defaultClientConfig
+  const clientConfig = resolveClientConfig(context.clientConfig)
 
   const message = params.message
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
   type DefaultProposal,
   type Proposal,
   type ProposalAdd,
+  type ProposalAppDataUpdate,
   type ProposalCustom,
   type ProposalExternalInit,
   type ProposalGroupContextExtensions,
@@ -17,7 +18,26 @@ export {
   type Remove,
   type Update,
   isDefaultProposal,
+  isAppDataUpdateProposal,
+  isCustomProposal,
 } from "./proposal.js"
+
+export {
+  appDataDictionaryExtensionType,
+  makeAppDataDictionaryExtension,
+  getAppDataDictionary,
+  type AppDataDictionary,
+  type ComponentData,
+} from "./appDataDictionary.js"
+
+export {
+  appDataUpdateProposalType,
+  appDataUpdateOperations,
+  defaultAppDataUpdateCallback,
+  type AppDataUpdate,
+  type AppDataUpdateCallback,
+  type AppDataUpdateOperationName,
+} from "./appDataUpdate.js"
 
 export {
   createGroup,

--- a/src/processMessages.ts
+++ b/src/processMessages.ts
@@ -336,10 +336,10 @@ async function processCommit(
 
   if (result.needsUpdatePath && content.commit.path === undefined) throw new ValidationError("Update path is required")
 
+  const updatedExtensions = result.additionalResult.kind === "reinit" ? undefined : result.additionalResult.extensions
+
   const groupContextWithExtensions =
-    result.additionalResult.kind === "memberCommit" && result.additionalResult.extensions !== undefined
-      ? { ...state.groupContext, extensions: result.additionalResult.extensions }
-      : state.groupContext
+    updatedExtensions !== undefined ? { ...state.groupContext, extensions: updatedExtensions } : state.groupContext
 
   const proposalTouchedLeaves: LeafIndex[] = [...result.updatedLeaves, ...result.removedLeaves]
   const [pkp, commitSecret, newTreeHash, treeHashCache] = await applyTreeUpdate(

--- a/src/processMessages.ts
+++ b/src/processMessages.ts
@@ -59,7 +59,14 @@ export type ProcessMessageResult =
       consumed: Uint8Array[]
       aad: Uint8Array
     }
-  | { kind: "applicationMessage"; message: Uint8Array; newState: ClientState; consumed: Uint8Array[]; aad: Uint8Array }
+  | {
+      kind: "applicationMessage"
+      message: Uint8Array
+      newState: ClientState
+      consumed: Uint8Array[]
+      aad: Uint8Array
+      senderLeafIndex: number | undefined
+    }
 
 /**
  * Process private message and apply proposal or commit and return the updated ClientState or return an application message
@@ -110,6 +117,7 @@ export async function processPrivateMessage(params: {
           newState,
           consumed: result.consumed,
           aad: result.content.content.authenticatedData,
+          senderLeafIndex: getSenderLeafNodeIndex(result.content.content.sender),
         }
       } else {
         throw new ValidationError("Cannot process commit or proposal from former epoch")
@@ -138,6 +146,7 @@ export async function processPrivateMessage(params: {
       newState: updatedState,
       consumed: result.consumed,
       aad: result.content.content.authenticatedData,
+      senderLeafIndex: getSenderLeafNodeIndex(result.content.content.sender),
     }
   } else if (result.content.content.contentType === contentTypes.commit) {
     if (result.content.auth.contentType !== result.content.content.contentType)

--- a/src/processMessages.ts
+++ b/src/processMessages.ts
@@ -48,7 +48,7 @@ import { zeroOutUint8Array } from "./util/byteArray.js"
 import { contentTypes } from "./contentType.js"
 import { AuthenticationService } from "./authenticationService.js"
 import type { MlsContext } from "./mlsContext.js"
-import { ClientConfig, defaultClientConfig } from "./clientConfig.js"
+import { ClientConfig, resolveClientConfig } from "./clientConfig.js"
 
 /** @public */
 export type ProcessMessageResult =
@@ -78,7 +78,7 @@ export async function processPrivateMessage(params: {
   const pskSearch = makePskIndex(state, context.externalPsks ?? {})
   const auth = context.authService
   const cb = params.callback ?? acceptAll
-  const clientConfig = context.clientConfig ?? defaultClientConfig
+  const clientConfig = resolveClientConfig(context.clientConfig)
 
   const pm = params.privateMessage
 
@@ -212,7 +212,7 @@ export async function processPublicMessage(params: {
   const cipherSuite = context.cipherSuite
   const pskSearch = makePskIndex(state, context.externalPsks ?? {})
   const auth = context.authService
-  const clientConfig = context.clientConfig ?? defaultClientConfig
+  const clientConfig = resolveClientConfig(context.clientConfig)
 
   const pm = params.publicMessage
   const callback = params.callback ?? acceptAll
@@ -518,7 +518,7 @@ export async function processMessage(params: {
   const authService = context.authService
   const cs = context.cipherSuite
   const externalPsks = context.externalPsks ?? {}
-  const clientConfig = context.clientConfig ?? defaultClientConfig
+  const clientConfig = resolveClientConfig(context.clientConfig)
 
   const message = params.message
   const action = params.callback ?? acceptAll

--- a/src/proposal.ts
+++ b/src/proposal.ts
@@ -13,6 +13,13 @@ import {
 } from "./defaultProposalType.js"
 import { protocolVersionDecoder, protocolVersionEncoder, ProtocolVersionValue } from "./protocolVersion.js"
 import { leafNodeUpdateDecoder, leafNodeEncoder, LeafNodeUpdate } from "./leafNode.js"
+import {
+  AppDataUpdate,
+  appDataUpdateDecoder,
+  appDataUpdateEncoder,
+  appDataUpdateProposalType,
+} from "./appDataUpdate.js"
+import { UsageError } from "./mlsError.js"
 
 /** @public */
 export interface Add {
@@ -129,6 +136,17 @@ export interface ProposalGroupContextExtensions {
   groupContextExtensions: GroupContextExtensions
 }
 
+/**
+ * The `app_data_update` proposal defined in draft-ietf-mls-extensions-09. Updates the
+ * `app_data_dictionary` GroupContext extension when committed.
+ *
+ * @public
+ */
+export interface ProposalAppDataUpdate {
+  proposalType: typeof appDataUpdateProposalType
+  appDataUpdate: AppDataUpdate
+}
+
 /** @public */
 export interface ProposalCustom {
   proposalType: number
@@ -146,11 +164,21 @@ export type DefaultProposal =
   | ProposalGroupContextExtensions
 
 /** @public */
-export type Proposal = DefaultProposal | ProposalCustom
+export type Proposal = DefaultProposal | ProposalAppDataUpdate | ProposalCustom
 
 /** @public */
 export function isDefaultProposal(p: Proposal): p is DefaultProposal {
   return isDefaultProposalTypeValue(p.proposalType)
+}
+
+/** @public */
+export function isAppDataUpdateProposal(p: Proposal): p is ProposalAppDataUpdate {
+  return p.proposalType === appDataUpdateProposalType && "appDataUpdate" in p
+}
+
+/** @public */
+export function isCustomProposal(p: Proposal): p is ProposalCustom {
+  return !isDefaultProposal(p) && !isAppDataUpdateProposal(p)
 }
 
 const proposalAddEncoder: Encoder<ProposalAdd> = contramapBufferEncoders(
@@ -188,13 +216,24 @@ const proposalGroupContextExtensionsEncoder: Encoder<ProposalGroupContextExtensi
   (p) => [p.proposalType, p.groupContextExtensions] as const,
 )
 
+const proposalAppDataUpdateEncoder: Encoder<ProposalAppDataUpdate> = contramapBufferEncoders(
+  [uint16Encoder, appDataUpdateEncoder],
+  (p) => [p.proposalType, p.appDataUpdate] as const,
+)
+
 const proposalCustomEncoder: Encoder<ProposalCustom> = contramapBufferEncoders(
   [uint16Encoder, varLenDataEncoder],
   (p) => [p.proposalType, p.proposalData] as const,
 )
 
 export const proposalEncoder: Encoder<Proposal> = (p) => {
-  if (!isDefaultProposal(p)) return proposalCustomEncoder(p)
+  if (isAppDataUpdateProposal(p)) return proposalAppDataUpdateEncoder(p)
+
+  if (!isDefaultProposal(p)) {
+    if (p.proposalType === appDataUpdateProposalType)
+      throw new UsageError("Cannot encode custom proposal with the app_data_update proposal type")
+    return proposalCustomEncoder(p)
+  }
 
   switch (p.proposalType) {
     case defaultProposalTypes.add:
@@ -252,6 +291,14 @@ const proposalGroupContextExtensionsDecoder: Decoder<ProposalGroupContextExtensi
   }),
 )
 
+const proposalAppDataUpdateDecoder: Decoder<ProposalAppDataUpdate> = mapDecoder(
+  appDataUpdateDecoder,
+  (appDataUpdate) => ({
+    proposalType: appDataUpdateProposalType,
+    appDataUpdate,
+  }),
+)
+
 function proposalCustomDecoder(proposalType: number): Decoder<ProposalCustom> {
   return mapDecoder(varLenDataDecoder, (proposalData) => ({ proposalType, proposalData }))
 }
@@ -275,5 +322,8 @@ export const proposalDecoder: Decoder<Proposal> = orDecoder(
         return proposalGroupContextExtensionsDecoder
     }
   }),
-  flatMapDecoder(uint16Decoder, (n) => proposalCustomDecoder(n)),
+  flatMapDecoder(uint16Decoder, (n): Decoder<Proposal> => {
+    if (n === appDataUpdateProposalType) return proposalAppDataUpdateDecoder
+    return proposalCustomDecoder(n)
+  }),
 )

--- a/test/codec/appData.test.ts
+++ b/test/codec/appData.test.ts
@@ -1,0 +1,142 @@
+import {
+  appDataDictionaryDecoder,
+  appDataDictionaryEncoder,
+  AppDataDictionary,
+  componentDataDecoder,
+  componentDataEncoder,
+  getAppDataDictionary,
+  makeAppDataDictionaryExtension,
+} from "../../src/appDataDictionary.js"
+import { appDataUpdateDecoder, appDataUpdateEncoder, AppDataUpdate } from "../../src/appDataUpdate.js"
+import { proposalDecoder, proposalEncoder, Proposal } from "../../src/proposal.js"
+import { decode } from "../../src/codec/tlsDecoder.js"
+import { encode } from "../../src/codec/tlsEncoder.js"
+import { UsageError } from "../../src/mlsError.js"
+import { createRoundtripTest } from "./roundtrip.js"
+
+describe("ComponentData roundtrip", () => {
+  const roundtrip = createRoundtripTest(componentDataEncoder, componentDataDecoder)
+
+  test("roundtrips component data", () => {
+    roundtrip({ componentId: 0x8001, data: new Uint8Array([1, 2, 3]) })
+  })
+
+  test("roundtrips empty data", () => {
+    roundtrip({ componentId: 1, data: new Uint8Array([]) })
+  })
+})
+
+describe("AppDataDictionary roundtrip", () => {
+  const roundtrip = createRoundtripTest(appDataDictionaryEncoder, appDataDictionaryDecoder)
+
+  test("roundtrips empty dictionary", () => {
+    roundtrip([])
+  })
+
+  test("roundtrips sorted dictionary", () => {
+    roundtrip([
+      { componentId: 1, data: new Uint8Array([1]) },
+      { componentId: 5, data: new Uint8Array([]) },
+      { componentId: 0x8001, data: new Uint8Array([0xde, 0xad]) },
+    ])
+  })
+
+  test("rejects unsorted dictionary", () => {
+    const unsorted: AppDataDictionary = [
+      { componentId: 5, data: new Uint8Array([]) },
+      { componentId: 1, data: new Uint8Array([]) },
+    ]
+    expect(decode(appDataDictionaryDecoder, encode(appDataDictionaryEncoder, unsorted))).toBeUndefined()
+  })
+
+  test("rejects duplicate entries", () => {
+    const duplicates: AppDataDictionary = [
+      { componentId: 1, data: new Uint8Array([]) },
+      { componentId: 1, data: new Uint8Array([1]) },
+    ]
+    expect(decode(appDataDictionaryDecoder, encode(appDataDictionaryEncoder, duplicates))).toBeUndefined()
+  })
+})
+
+describe("AppDataDictionary extension helpers", () => {
+  test("roundtrips through a GroupContext extension", () => {
+    const dictionary: AppDataDictionary = [{ componentId: 2, data: new Uint8Array([7, 8, 9]) }]
+    const extension = makeAppDataDictionaryExtension(dictionary)
+    expect(getAppDataDictionary([extension])).toStrictEqual(dictionary)
+  })
+
+  test("returns undefined when no extension is present", () => {
+    expect(getAppDataDictionary([])).toBeUndefined()
+  })
+
+  test("rejects unsorted dictionaries", () => {
+    expect(() =>
+      makeAppDataDictionaryExtension([
+        { componentId: 5, data: new Uint8Array([]) },
+        { componentId: 1, data: new Uint8Array([]) },
+      ]),
+    ).toThrow(UsageError)
+  })
+})
+
+describe("AppDataUpdate roundtrip", () => {
+  const roundtrip = createRoundtripTest(appDataUpdateEncoder, appDataUpdateDecoder)
+
+  test("roundtrips update operation", () => {
+    const update: AppDataUpdate = { componentId: 0x8001, operation: "update", update: new Uint8Array([1, 2, 3]) }
+    roundtrip(update)
+  })
+
+  test("roundtrips remove operation", () => {
+    const remove: AppDataUpdate = { componentId: 7, operation: "remove" }
+    roundtrip(remove)
+  })
+
+  test("rejects invalid operation", () => {
+    // componentId 1, operation invalid(0)
+    expect(decode(appDataUpdateDecoder, new Uint8Array([0, 1, 0]))).toBeUndefined()
+  })
+
+  test("encodes the draft-09 wire format exactly", () => {
+    const update: AppDataUpdate = { componentId: 0x8001, operation: "update", update: new Uint8Array([1, 2, 3]) }
+    expect(encode(appDataUpdateEncoder, update)).toStrictEqual(
+      new Uint8Array([0x80, 0x01, 0x01, 0x03, 0x01, 0x02, 0x03]),
+    )
+
+    const remove: AppDataUpdate = { componentId: 7, operation: "remove" }
+    expect(encode(appDataUpdateEncoder, remove)).toStrictEqual(new Uint8Array([0x00, 0x07, 0x02]))
+
+    const dictionary: AppDataDictionary = [{ componentId: 2, data: new Uint8Array([7, 8, 9]) }]
+    expect(encode(appDataDictionaryEncoder, dictionary)).toStrictEqual(
+      new Uint8Array([0x06, 0x00, 0x02, 0x03, 0x07, 0x08, 0x09]),
+    )
+  })
+})
+
+describe("app_data_update Proposal roundtrip", () => {
+  const roundtrip = createRoundtripTest(proposalEncoder, proposalDecoder)
+
+  test("roundtrips an update proposal", () => {
+    const proposal: Proposal = {
+      proposalType: 8,
+      appDataUpdate: { componentId: 0x8001, operation: "update", update: new Uint8Array([4, 5, 6]) },
+    }
+    roundtrip(proposal)
+  })
+
+  test("roundtrips a remove proposal", () => {
+    const proposal: Proposal = {
+      proposalType: 8,
+      appDataUpdate: { componentId: 0x8001, operation: "remove" },
+    }
+    roundtrip(proposal)
+  })
+
+  test("rejects a custom proposal with the app_data_update proposal type", () => {
+    const proposal: Proposal = {
+      proposalType: 8,
+      proposalData: new Uint8Array([1, 2, 3]),
+    }
+    expect(() => encode(proposalEncoder, proposal)).toThrow(UsageError)
+  })
+})

--- a/test/scenario/appDataUpdate.test.ts
+++ b/test/scenario/appDataUpdate.test.ts
@@ -385,6 +385,72 @@ test("AppDataUpdate proposals cannot appear before a GroupContextExtensions prop
   ).rejects.toThrow(ValidationError)
 })
 
+test("GroupContextExtensions cannot drop the AppDataUpdate required capability while modifying the dictionary", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([0]) }]
+  const requiredCapabilities: GroupContextExtension = {
+    extensionType: defaultExtensionTypes.required_capabilities,
+    extensionData: {
+      extensionTypes: [appDataDictionaryExtensionType],
+      proposalTypes: [appDataUpdateProposalType],
+      credentialTypes: [],
+    },
+  }
+
+  const { aliceGroup } = await setup(defaultSuite, impl, [
+    requiredCapabilities,
+    makeAppDataDictionaryExtension(initialDictionary),
+  ])
+
+  // the proposed extensions no longer require the AppDataUpdate proposal type and
+  // at the same time replace the dictionary; the current group context still
+  // requires it, so the dictionary must remain protected
+  const gceProposal: Proposal = {
+    proposalType: defaultProposalTypes.group_context_extensions,
+    groupContextExtensions: {
+      extensions: [makeAppDataDictionaryExtension([{ componentId, data: new Uint8Array([0xff]) }])],
+    },
+  }
+
+  await expect(
+    createCommitEnsureNoMutation({
+      context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+      state: aliceGroup,
+      extraProposals: [gceProposal],
+    }),
+  ).rejects.toThrow(ValidationError)
+})
+
+test("A partial ClientConfig without appDataUpdateCallback falls back to the default", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  // simulates a JS caller that constructed its config before appDataUpdateCallback existed
+  const partialClientConfig = {} as ClientConfig
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([0]) }]
+
+  let { aliceGroup, bobGroup } = await setup(
+    defaultSuite,
+    impl,
+    [makeAppDataDictionaryExtension(initialDictionary)],
+    partialClientConfig,
+  )
+
+  const newData = new Uint8Array([1, 2, 3])
+  ;({ aliceGroup, bobGroup } = await commitAndProcess(
+    impl,
+    aliceGroup,
+    bobGroup,
+    [updateProposal(componentId, newData)],
+    partialClientConfig,
+  ))
+
+  const expected: AppDataDictionary = [{ componentId, data: newData }]
+  expect(dictionaryOf(aliceGroup)).toStrictEqual(expected)
+  expect(dictionaryOf(bobGroup)).toStrictEqual(expected)
+})
+
 test("GroupContextExtensions cannot modify the dictionary when required capabilities include AppDataUpdate", async () => {
   const impl = await getCiphersuiteImpl(defaultSuite)
 

--- a/test/scenario/appDataUpdate.test.ts
+++ b/test/scenario/appDataUpdate.test.ts
@@ -1,0 +1,424 @@
+import { ClientState, createGroup, joinGroup } from "../../src/clientState.js"
+import { ClientConfig, defaultClientConfig } from "../../src/clientConfig.js"
+import { Credential } from "../../src/credential.js"
+import { defaultCredentialTypes } from "../../src/defaultCredentialType.js"
+import { CiphersuiteImpl, CiphersuiteName, ciphersuites } from "../../src/crypto/ciphersuite.js"
+import { getCiphersuiteImpl } from "../../src/crypto/getCiphersuiteImpl.js"
+import { generateKeyPackage } from "../../src/keyPackage.js"
+import { Proposal, ProposalAppDataUpdate } from "../../src/proposal.js"
+import { defaultProposalTypes } from "../../src/defaultProposalType.js"
+import { defaultExtensionTypes } from "../../src/defaultExtensionType.js"
+import { unsafeTestingAuthenticationService } from "../../src/authenticationService.js"
+import { Capabilities } from "../../src/capabilities.js"
+import { protocolVersions } from "../../src/protocolVersion.js"
+import {
+  AppDataDictionary,
+  appDataDictionaryExtensionType,
+  getAppDataDictionary,
+  makeAppDataDictionaryExtension,
+} from "../../src/appDataDictionary.js"
+import { appDataUpdateProposalType } from "../../src/appDataUpdate.js"
+import { GroupContextExtension } from "../../src/extension.js"
+import { ValidationError } from "../../src/mlsError.js"
+import { createProposal } from "../../src/createMessage.js"
+import {
+  createCommitEnsureNoMutation,
+  processMessageEnsureNoMutation,
+  testEveryoneCanMessageEveryone,
+} from "./common.js"
+
+const defaultSuite: CiphersuiteName = "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519"
+
+const componentId = 0x8001
+const otherComponentId = 0x8002
+
+test.concurrent.each(Object.keys(ciphersuites))(
+  `Commit with AppDataUpdate proposal updates the app_data_dictionary %s`,
+  async (cs) => {
+    await appDataUpdateCommitTest(cs as CiphersuiteName)
+  },
+)
+
+function appDataCapabilities(cipherSuite: CiphersuiteName): Capabilities {
+  return {
+    extensions: [appDataDictionaryExtensionType],
+    credentials: [defaultCredentialTypes.basic],
+    proposals: [appDataUpdateProposalType],
+    versions: [protocolVersions.mls10],
+    ciphersuites: [ciphersuites[cipherSuite]],
+  }
+}
+
+function updateProposal(component: number, data: Uint8Array): ProposalAppDataUpdate {
+  return {
+    proposalType: appDataUpdateProposalType,
+    appDataUpdate: { componentId: component, operation: "update", update: data },
+  }
+}
+
+function removeProposal(component: number): ProposalAppDataUpdate {
+  return {
+    proposalType: appDataUpdateProposalType,
+    appDataUpdate: { componentId: component, operation: "remove" },
+  }
+}
+
+function dictionaryOf(state: ClientState): AppDataDictionary | undefined {
+  return getAppDataDictionary(state.groupContext.extensions)
+}
+
+/** Builds a two member group where alice is the committer and bob joined via welcome. */
+async function setup(
+  cipherSuite: CiphersuiteName,
+  impl: CiphersuiteImpl,
+  extensions: GroupContextExtension[],
+  clientConfig?: ClientConfig,
+): Promise<{ aliceGroup: ClientState; bobGroup: ClientState }> {
+  const capabilities = appDataCapabilities(cipherSuite)
+
+  const aliceCredential: Credential = {
+    credentialType: defaultCredentialTypes.basic,
+    identity: new TextEncoder().encode("alice"),
+  }
+  const alice = await generateKeyPackage({ credential: aliceCredential, capabilities, cipherSuite: impl })
+
+  const bobCredential: Credential = {
+    credentialType: defaultCredentialTypes.basic,
+    identity: new TextEncoder().encode("bob"),
+  }
+  const bob = await generateKeyPackage({ credential: bobCredential, capabilities, cipherSuite: impl })
+
+  const aliceGroup = await createGroup({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService, clientConfig },
+    groupId: new TextEncoder().encode("group1"),
+    keyPackage: alice.publicPackage,
+    privateKeyPackage: alice.privatePackage,
+    extensions,
+  })
+
+  const addBobCommit = await createCommitEnsureNoMutation({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService, clientConfig },
+    state: aliceGroup,
+    extraProposals: [{ proposalType: defaultProposalTypes.add, add: { keyPackage: bob.publicPackage } }],
+    ratchetTreeExtension: true,
+  })
+
+  const bobGroup = await joinGroup({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService, clientConfig },
+    welcome: addBobCommit.welcome!.welcome,
+    keyPackage: bob.publicPackage,
+    privateKeys: bob.privatePackage,
+  })
+
+  return { aliceGroup: addBobCommit.newState, bobGroup }
+}
+
+/** Commits the proposals at alice and processes the commit at bob. */
+async function commitAndProcess(
+  impl: CiphersuiteImpl,
+  aliceGroup: ClientState,
+  bobGroup: ClientState,
+  proposals: Proposal[],
+  clientConfig?: ClientConfig,
+): Promise<{ aliceGroup: ClientState; bobGroup: ClientState }> {
+  const commitResult = await createCommitEnsureNoMutation({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService, clientConfig },
+    state: aliceGroup,
+    extraProposals: proposals,
+  })
+
+  const processResult = await processMessageEnsureNoMutation({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService, clientConfig },
+    state: bobGroup,
+    message: commitResult.commit,
+  })
+
+  if (processResult.kind !== "newState") throw new Error("Expected new state")
+
+  return { aliceGroup: commitResult.newState, bobGroup: processResult.newState }
+}
+
+async function appDataUpdateCommitTest(cipherSuite: CiphersuiteName) {
+  const impl = await getCiphersuiteImpl(cipherSuite)
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([0]) }]
+
+  let { aliceGroup, bobGroup } = await setup(cipherSuite, impl, [makeAppDataDictionaryExtension(initialDictionary)])
+
+  expect(dictionaryOf(bobGroup)).toStrictEqual(initialDictionary)
+
+  const newData = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
+  ;({ aliceGroup, bobGroup } = await commitAndProcess(impl, aliceGroup, bobGroup, [
+    updateProposal(componentId, newData),
+  ]))
+
+  const expected: AppDataDictionary = [{ componentId, data: newData }]
+  expect(dictionaryOf(aliceGroup)).toStrictEqual(expected)
+  expect(dictionaryOf(bobGroup)).toStrictEqual(expected)
+  expect(bobGroup.groupContext.epoch).toBe(aliceGroup.groupContext.epoch)
+
+  await testEveryoneCanMessageEveryone([aliceGroup, bobGroup], impl)
+}
+
+test("AppDataUpdate creates the app_data_dictionary extension when absent", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  let { aliceGroup, bobGroup } = await setup(defaultSuite, impl, [])
+
+  expect(dictionaryOf(aliceGroup)).toBeUndefined()
+
+  const data = new Uint8Array([1, 2, 3])
+  ;({ aliceGroup, bobGroup } = await commitAndProcess(impl, aliceGroup, bobGroup, [updateProposal(componentId, data)]))
+
+  const expected: AppDataDictionary = [{ componentId, data }]
+  expect(dictionaryOf(aliceGroup)).toStrictEqual(expected)
+  expect(dictionaryOf(bobGroup)).toStrictEqual(expected)
+})
+
+test("Multiple AppDataUpdate proposals for the same component apply in order (last update wins by default)", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  let { aliceGroup, bobGroup } = await setup(defaultSuite, impl, [])
+
+  const last = new Uint8Array([9])
+  ;({ aliceGroup, bobGroup } = await commitAndProcess(impl, aliceGroup, bobGroup, [
+    updateProposal(componentId, new Uint8Array([1])),
+    updateProposal(componentId, new Uint8Array([2])),
+    updateProposal(componentId, last),
+  ]))
+
+  expect(dictionaryOf(aliceGroup)).toStrictEqual([{ componentId, data: last }])
+  expect(dictionaryOf(bobGroup)).toStrictEqual([{ componentId, data: last }])
+})
+
+test("A custom appDataUpdateCallback controls how updates are applied", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  // application logic that concatenates all updates onto the current data
+  const clientConfig: ClientConfig = {
+    ...defaultClientConfig,
+    appDataUpdateCallback: (_componentId, currentData, updates) => {
+      const parts = [currentData ?? new Uint8Array([]), ...updates]
+      const result = new Uint8Array(parts.reduce((acc, p) => acc + p.length, 0))
+      let offset = 0
+      for (const part of parts) {
+        result.set(part, offset)
+        offset += part.length
+      }
+      return result
+    },
+  }
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([0]) }]
+
+  let { aliceGroup, bobGroup } = await setup(
+    defaultSuite,
+    impl,
+    [makeAppDataDictionaryExtension(initialDictionary)],
+    clientConfig,
+  )
+  ;({ aliceGroup, bobGroup } = await commitAndProcess(
+    impl,
+    aliceGroup,
+    bobGroup,
+    [updateProposal(componentId, new Uint8Array([1])), updateProposal(componentId, new Uint8Array([2]))],
+    clientConfig,
+  ))
+
+  const expected: AppDataDictionary = [{ componentId, data: new Uint8Array([0, 1, 2]) }]
+  expect(dictionaryOf(aliceGroup)).toStrictEqual(expected)
+  expect(dictionaryOf(bobGroup)).toStrictEqual(expected)
+})
+
+test("AppDataUpdate remove operation removes the component entry", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const initialDictionary: AppDataDictionary = [
+    { componentId, data: new Uint8Array([1]) },
+    { componentId: otherComponentId, data: new Uint8Array([2]) },
+  ]
+
+  let { aliceGroup, bobGroup } = await setup(defaultSuite, impl, [makeAppDataDictionaryExtension(initialDictionary)])
+  ;({ aliceGroup, bobGroup } = await commitAndProcess(impl, aliceGroup, bobGroup, [removeProposal(componentId)]))
+
+  const expected: AppDataDictionary = [{ componentId: otherComponentId, data: new Uint8Array([2]) }]
+  expect(dictionaryOf(aliceGroup)).toStrictEqual(expected)
+  expect(dictionaryOf(bobGroup)).toStrictEqual(expected)
+})
+
+test("AppDataUpdate inserts new components sorted by componentId", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const initialDictionary: AppDataDictionary = [{ componentId: otherComponentId, data: new Uint8Array([2]) }]
+
+  let { aliceGroup, bobGroup } = await setup(defaultSuite, impl, [makeAppDataDictionaryExtension(initialDictionary)])
+  ;({ aliceGroup, bobGroup } = await commitAndProcess(impl, aliceGroup, bobGroup, [
+    updateProposal(componentId, new Uint8Array([1])),
+  ]))
+
+  const expected: AppDataDictionary = [
+    { componentId, data: new Uint8Array([1]) },
+    { componentId: otherComponentId, data: new Uint8Array([2]) },
+  ]
+  expect(dictionaryOf(aliceGroup)).toStrictEqual(expected)
+  expect(dictionaryOf(bobGroup)).toStrictEqual(expected)
+})
+
+test("AppDataUpdate remove for a component without state is invalid", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const { aliceGroup } = await setup(defaultSuite, impl, [])
+
+  await expect(
+    createCommitEnsureNoMutation({
+      context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+      state: aliceGroup,
+      extraProposals: [removeProposal(componentId)],
+    }),
+  ).rejects.toThrow(ValidationError)
+})
+
+test("AppDataUpdate update and remove for the same component is invalid", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([1]) }]
+  const { aliceGroup } = await setup(defaultSuite, impl, [makeAppDataDictionaryExtension(initialDictionary)])
+
+  await expect(
+    createCommitEnsureNoMutation({
+      context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+      state: aliceGroup,
+      extraProposals: [updateProposal(componentId, new Uint8Array([2])), removeProposal(componentId)],
+    }),
+  ).rejects.toThrow(ValidationError)
+})
+
+test("Multiple AppDataUpdate removes for the same component are invalid", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([1]) }]
+  const { aliceGroup } = await setup(defaultSuite, impl, [makeAppDataDictionaryExtension(initialDictionary)])
+
+  await expect(
+    createCommitEnsureNoMutation({
+      context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+      state: aliceGroup,
+      extraProposals: [removeProposal(componentId), removeProposal(componentId)],
+    }),
+  ).rejects.toThrow(ValidationError)
+})
+
+test("AppDataUpdate works as a standalone proposal that is committed later", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([0]) }]
+
+  let { aliceGroup, bobGroup } = await setup(defaultSuite, impl, [makeAppDataDictionaryExtension(initialDictionary)])
+
+  const data = new Uint8Array([1, 2, 3])
+
+  // bob sends a standalone proposal
+  const proposalResult = await createProposal({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+    state: bobGroup,
+    wireAsPublicMessage: false,
+    proposal: updateProposal(componentId, data),
+  })
+  bobGroup = proposalResult.newState
+
+  // alice receives the proposal and commits it
+  const processProposalResult = await processMessageEnsureNoMutation({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+    state: aliceGroup,
+    message: proposalResult.message,
+  })
+  if (processProposalResult.kind !== "newState") throw new Error("Expected new state")
+  aliceGroup = processProposalResult.newState
+  ;({ aliceGroup, bobGroup } = await commitAndProcess(impl, aliceGroup, bobGroup, []))
+
+  const expected: AppDataDictionary = [{ componentId, data }]
+  expect(dictionaryOf(aliceGroup)).toStrictEqual(expected)
+  expect(dictionaryOf(bobGroup)).toStrictEqual(expected)
+})
+
+test("GroupContextExtensions and AppDataUpdate proposals can be combined in one commit", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([0]) }]
+
+  let { aliceGroup, bobGroup } = await setup(defaultSuite, impl, [makeAppDataDictionaryExtension(initialDictionary)])
+
+  const newData = new Uint8Array([1])
+  const gceProposal: Proposal = {
+    proposalType: defaultProposalTypes.group_context_extensions,
+    // GCE replaces the whole extension set; carry the dictionary forward unchanged
+    groupContextExtensions: { extensions: aliceGroup.groupContext.extensions },
+  }
+
+  ;({ aliceGroup, bobGroup } = await commitAndProcess(impl, aliceGroup, bobGroup, [
+    gceProposal,
+    updateProposal(componentId, newData),
+  ]))
+
+  const expected: AppDataDictionary = [{ componentId, data: newData }]
+  expect(dictionaryOf(aliceGroup)).toStrictEqual(expected)
+  expect(dictionaryOf(bobGroup)).toStrictEqual(expected)
+})
+
+test("AppDataUpdate proposals cannot appear before a GroupContextExtensions proposal", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([0]) }]
+  const { aliceGroup } = await setup(defaultSuite, impl, [makeAppDataDictionaryExtension(initialDictionary)])
+
+  const gceProposal: Proposal = {
+    proposalType: defaultProposalTypes.group_context_extensions,
+    groupContextExtensions: { extensions: aliceGroup.groupContext.extensions },
+  }
+
+  await expect(
+    createCommitEnsureNoMutation({
+      context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+      state: aliceGroup,
+      extraProposals: [updateProposal(componentId, new Uint8Array([1])), gceProposal],
+    }),
+  ).rejects.toThrow(ValidationError)
+})
+
+test("GroupContextExtensions cannot modify the dictionary when required capabilities include AppDataUpdate", async () => {
+  const impl = await getCiphersuiteImpl(defaultSuite)
+
+  const initialDictionary: AppDataDictionary = [{ componentId, data: new Uint8Array([0]) }]
+  const requiredCapabilities: GroupContextExtension = {
+    extensionType: defaultExtensionTypes.required_capabilities,
+    extensionData: {
+      extensionTypes: [appDataDictionaryExtensionType],
+      proposalTypes: [appDataUpdateProposalType],
+      credentialTypes: [],
+    },
+  }
+
+  const { aliceGroup } = await setup(defaultSuite, impl, [
+    requiredCapabilities,
+    makeAppDataDictionaryExtension(initialDictionary),
+  ])
+
+  const gceProposal: Proposal = {
+    proposalType: defaultProposalTypes.group_context_extensions,
+    groupContextExtensions: {
+      extensions: aliceGroup.groupContext.extensions.map((e) =>
+        e.extensionType === appDataDictionaryExtensionType
+          ? makeAppDataDictionaryExtension([{ componentId, data: new Uint8Array([0xff]) }])
+          : e,
+      ),
+    },
+  }
+
+  await expect(
+    createCommitEnsureNoMutation({
+      context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+      state: aliceGroup,
+      extraProposals: [gceProposal],
+    }),
+  ).rejects.toThrow(ValidationError)
+})

--- a/test/scenario/authenticatedData.test.ts
+++ b/test/scenario/authenticatedData.test.ts
@@ -29,7 +29,9 @@ async function authenticatedDataScenario(cipherSuite: CiphersuiteName) {
   const impl = await getCiphersuiteImpl(cipherSuite)
   const encoder = new TextEncoder()
 
-  const customProposalType = 8
+  // 8 is assigned to app_data_update by draft-ietf-mls-extensions-09, so use a
+  // value without assigned semantics here
+  const customProposalType = 0xf123
 
   const base = defaultCapabilities()
   const capabilities: Capabilities = {

--- a/test/scenario/customProposal.test.ts
+++ b/test/scenario/customProposal.test.ts
@@ -25,7 +25,9 @@ test.concurrent.each(Object.keys(ciphersuites))(`Custom Proposals %s`, async (cs
 async function customProposalTest(cipherSuite: CiphersuiteName) {
   const impl = await getCiphersuiteImpl(cipherSuite)
 
-  const customProposalType: number = 8
+  // 8 is assigned to app_data_update by draft-ietf-mls-extensions-09, so use a
+  // value without assigned semantics here
+  const customProposalType: number = 0xf123
 
   const capabilities: Capabilities = {
     extensions: [],
@@ -96,7 +98,7 @@ async function customProposalTest(cipherSuite: CiphersuiteName) {
   const proposalData = new TextEncoder().encode("custom proposal data")
 
   const customProposal: Proposal = {
-    proposalType: 8,
+    proposalType: customProposalType,
     proposalData: proposalData,
   }
 


### PR DESCRIPTION
This PR adds support for `app_data_dictionary` (0x0006) + `app_data_update` (0x0008) extensions from [draft-ietf-mls-extensions-09 §4.7](https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions-09#section-4.7)

I'm using these extensions in the [marmot-ts](https://github.com/marmot-protocol/marmot-ts/tree/dark-matter) library implementing the [marmot/darkmatter](https://github.com/marmot-protocol/darkmatter/blob/master/spec/app-components/README.md) spec.

I'm still learning more about MLS, which is why this PR was created using claude so let me know if there is anything I can do to help verify this code is clean and good for the library.
I followed the CONTRIBUTING.md guide and everything passed although I was not able to test the playwright tests locally.