### PR TITLE
Prefer processMessage over public or private specific methods

### DIFF
--- a/api/ts-mls.api.md
+++ b/api/ts-mls.api.md
@@ -845,7 +845,7 @@ export function joinGroupExternal(params: {
     tree?: RatchetTree;
     authenticatedData?: Uint8Array;
 }): Promise<{
-    publicMessage: PublicMessage;
+    commit: MlsPublicMessage;
     newState: ClientState;
 }>;
 

--- a/docs/07-external-join.md
+++ b/docs/07-external-join.md
@@ -31,7 +31,7 @@ import {
   Proposal,
   joinGroup,
   joinGroupExternal,
-  processPublicMessage,
+  processMessage,
   createGroupInfoWithExternalPubAndRatchetTree,
   unsafeTestingAuthenticationService,
   zeroOutUint8Array,
@@ -101,19 +101,19 @@ const charlieJoinGroupCommitResult = await joinGroupExternal({
 let charlieGroup = charlieJoinGroupCommitResult.newState
 
 // All members process the external join commit to update their state (epoch 2)
-const aliceProcessCharlieJoinResult = await processPublicMessage({
+const aliceProcessCharlieJoinResult = await processMessage({
   context,
   state: aliceGroup,
-  publicMessage: charlieJoinGroupCommitResult.publicMessage,
+  message: charlieJoinGroupCommitResult.commit,
 })
 
 aliceGroup = aliceProcessCharlieJoinResult.newState
 aliceProcessCharlieJoinResult.consumed.forEach(zeroOutUint8Array)
 
-const bobProcessCharlieJoinResult = await processPublicMessage({
+const bobProcessCharlieJoinResult = await processMessage({
   context,
   state: bobGroup,
-  publicMessage: charlieJoinGroupCommitResult.publicMessage,
+  message: charlieJoinGroupCommitResult.commit,
 })
 
 bobGroup = bobProcessCharlieJoinResult.newState

--- a/interop/src/service.ts
+++ b/interop/src/service.ts
@@ -42,7 +42,6 @@ import {
   type GroupContextExtension,
   type Credential,
   type MlsContext,
-  type MlsMessage,
   type MlsFramedMessage,
   type ClientState,
   type ExternalSender,
@@ -426,14 +425,9 @@ export function makeService(store: Store): grpc.UntypedServiceImplementation {
           cipherSuite,
           wireAsPublicMessage: !req.encrypt_handshake,
         })
-        const commitMsg: MlsMessage = {
-          version: protocolVersions.mls10,
-          wireformat: wireformats.mls_public_message,
-          publicMessage: result.publicMessage,
-        }
         return {
           state_id,
-          commit: encode(mlsMessageEncoder, commitMsg),
+          commit: encode(mlsMessageEncoder, result.commit),
           epoch_authenticator: result.newState.keySchedule.epochAuthenticator,
         }
       },

--- a/src/createCommit.ts
+++ b/src/createCommit.ts
@@ -30,7 +30,7 @@ import {
 } from "./groupInfo.js"
 import { KeyPackage, makeKeyPackageRef, PrivateKeyPackage } from "./keyPackage.js"
 import { initializeEpoch, EpochSecrets } from "./keySchedule.js"
-import { MlsFramedMessage, MlsWelcomeMessage } from "./message.js"
+import { MlsFramedMessage, MlsPublicMessage, MlsWelcomeMessage } from "./message.js"
 import { protect } from "./messageProtection.js"
 import { protectPublicMessage } from "./messageProtectionPublic.js"
 import { getCommitSecret, pathToPathSecrets } from "./pathSecrets.js"
@@ -67,7 +67,6 @@ import { CryptoVerificationError, InternalError, UsageError, ValidationError } f
 import { ClientConfig, defaultClientConfig } from "./clientConfig.js"
 import { ExtensionExternalPub, extensionsSupportedByCapabilities, GroupInfoExtension } from "./extension.js"
 import { encode } from "./codec/tlsEncoder.js"
-import { PublicMessage } from "./publicMessage.js"
 import { wireformats } from "./wireformat.js"
 import { MlsContext } from "./mlsContext.js"
 
@@ -548,7 +547,7 @@ export async function joinGroupExternal(params: {
   resync: boolean
   tree?: RatchetTree
   authenticatedData?: Uint8Array
-}): Promise<{ publicMessage: PublicMessage; newState: ClientState }> {
+}): Promise<{ commit: MlsPublicMessage; newState: ClientState }> {
   const context = params.context
   const groupInfo = params.groupInfo
   const keyPackage = params.keyPackage
@@ -715,7 +714,10 @@ export async function joinGroupExternal(params: {
   zeroOutUint8Array(initSecret)
   zeroOutUint8Array(epochSecrets.joinerSecret)
 
-  return { publicMessage: msg, newState: state }
+  return {
+    commit: { publicMessage: msg, wireformat: wireformats.mls_public_message, version: protocolVersions.mls10 },
+    newState: state,
+  }
 }
 function filterNewLeaves(resolution: NodeIndex[], excludeNodes: NodeIndex[]): NodeIndex[] {
   const set = new Set(excludeNodes)

--- a/test/clientState.test.ts
+++ b/test/clientState.test.ts
@@ -12,12 +12,12 @@ import { Credential, isDefaultCredential } from "../src/credential.js"
 import { getCiphersuiteImpl } from "../src/crypto/getCiphersuiteImpl.js"
 import { CiphersuiteName } from "../src/crypto/ciphersuite.js"
 import { createCommit } from "../src/createCommit.js"
-import { processPrivateMessage } from "../src/processMessages.js"
 import { defaultProposalTypes } from "../src/defaultProposalType.js"
 import { defaultCredentialTypes } from "../src/defaultCredentialType.js"
 import { LeafNode } from "../src/leafNode.js"
 import { wireformats } from "../src/wireformat.js"
 import { unsafeTestingAuthenticationService } from "../src/authenticationService.js"
+import { processMessageEnsureNoMutation } from "./scenario/common.js"
 
 const SUITE: CiphersuiteName = "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519"
 
@@ -89,13 +89,13 @@ async function buildThreeMemberGroup() {
   aliceGroup = addCharlieCommitResult.newState
   if (addCharlieCommitResult.commit.wireformat !== wireformats.mls_private_message)
     throw new Error("Expected private message")
-  const processAddCharlieResult = await processPrivateMessage({
+  const processAddCharlieResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    privateMessage: addCharlieCommitResult.commit.privateMessage,
+    message: addCharlieCommitResult.commit,
   })
   bobGroup = processAddCharlieResult.newState
   const charlieGroup = await joinGroup({

--- a/test/scenario/addPlusPathCommit.test.ts
+++ b/test/scenario/addPlusPathCommit.test.ts
@@ -11,7 +11,7 @@ import { unsafeTestingAuthenticationService } from "../../src/authenticationServ
 import { wireformats } from "../../src/wireformat.js"
 import {
   createCommitEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 import { checkHpkeKeysMatch } from "../crypto/keyMatch.js"
@@ -107,10 +107,10 @@ async function addPlusPathCommitTest(cipherSuite: CiphersuiteName) {
 
   if (bigCommit.commit.wireformat !== wireformats.mls_private_message) throw new Error("Expected private message")
 
-  const bobAfter = await processPrivateMessageEnsureNoMutation({
+  const bobAfter = await processMessageEnsureNoMutation({
     context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
     state: bobGroup,
-    privateMessage: bigCommit.commit.privateMessage,
+    message: bigCommit.commit,
   })
   bobGroup = bobAfter.newState
 

--- a/test/scenario/authenticatedData.test.ts
+++ b/test/scenario/authenticatedData.test.ts
@@ -6,7 +6,6 @@ import { getCiphersuiteImpl } from "../../src/crypto/getCiphersuiteImpl.js"
 import { Credential } from "../../src/credential.js"
 import { defaultCredentialTypes } from "../../src/defaultCredentialType.js"
 import { CryptoError, CryptoVerificationError } from "../../src/mlsError.js"
-import { processPublicMessage } from "../../src/processMessages.js"
 import { Capabilities } from "../../src/capabilities.js"
 
 import { protocolVersions } from "../../src/protocolVersion.js"
@@ -15,11 +14,7 @@ import { Proposal } from "../../src/proposal.js"
 import { wireformats } from "../../src/wireformat.js"
 import { unsafeTestingAuthenticationService } from "../../src/authenticationService.js"
 import { defaultCapabilities } from "../../src/defaultCapabilities.js"
-import {
-  createCommitEnsureNoMutation,
-  processMessageEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
-} from "./common.js"
+import { createCommitEnsureNoMutation, processMessageEnsureNoMutation } from "./common.js"
 
 test.concurrent.each(Object.keys(ciphersuites))("authenticatedData verified for app/proposal/commit %s", async (cs) => {
   await authenticatedDataScenario(cs as CiphersuiteName)
@@ -105,17 +100,17 @@ async function authenticatedDataScenario(cipherSuite: CiphersuiteName) {
   if (aliceAppResult.message.wireformat !== wireformats.mls_private_message) throw new Error("Expected private message")
 
   const tamperedApp = {
-    ...aliceAppResult.message.privateMessage,
-    authenticatedData: encoder.encode("aad-app-tampered"),
+    ...aliceAppResult.message,
+    privateMessage: { ...aliceAppResult.message.privateMessage, authenticatedData: encoder.encode("aad-app-tampered") },
   }
   await expect(
-    processPrivateMessageEnsureNoMutation({
+    processMessageEnsureNoMutation({
       context: {
         cipherSuite: impl,
         authService: unsafeTestingAuthenticationService,
       },
       state: bobGroup,
-      privateMessage: tamperedApp,
+      message: tamperedApp,
     }),
   ).rejects.toThrow(CryptoError)
 
@@ -152,17 +147,20 @@ async function authenticatedDataScenario(cipherSuite: CiphersuiteName) {
     throw new Error("Expected private message")
 
   const tamperedProposal = {
-    ...bobProposalResult.message.privateMessage,
-    authenticatedData: encoder.encode("aad-proposal-tampered"),
+    ...bobProposalResult.message,
+    privateMessage: {
+      ...bobProposalResult.message.privateMessage,
+      authenticatedData: encoder.encode("aad-proposal-tampered"),
+    },
   }
   await expect(
-    processPrivateMessageEnsureNoMutation({
+    processMessageEnsureNoMutation({
       context: {
         cipherSuite: impl,
         authService: unsafeTestingAuthenticationService,
       },
       state: aliceGroup,
-      privateMessage: tamperedProposal,
+      message: tamperedProposal,
       callback: () => {
         throw new Error("Callback should not run for tampered authenticatedData")
       },
@@ -204,30 +202,34 @@ async function authenticatedDataScenario(cipherSuite: CiphersuiteName) {
     throw new Error("Expected private message")
 
   const tamperedCommit = {
-    ...aliceCommitResult.commit.privateMessage,
-    authenticatedData: encoder.encode("aad-commit-tampered"),
+    ...aliceCommitResult.commit,
+    privateMessage: {
+      ...aliceCommitResult.commit.privateMessage,
+
+      authenticatedData: encoder.encode("aad-commit-tampered"),
+    },
   }
   await expect(
-    processPrivateMessageEnsureNoMutation({
+    processMessageEnsureNoMutation({
       context: {
         cipherSuite: impl,
         authService: unsafeTestingAuthenticationService,
       },
       state: bobGroup,
-      privateMessage: tamperedCommit,
+      message: tamperedCommit,
       callback: () => {
         throw new Error("Callback should not run for tampered authenticatedData")
       },
     }),
   ).rejects.toThrow(CryptoError)
 
-  const bobProcessCommitResult = await processPrivateMessageEnsureNoMutation({
+  const bobProcessCommitResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    privateMessage: aliceCommitResult.commit.privateMessage,
+    message: aliceCommitResult.commit,
     callback: (incoming) => {
       if (incoming.kind !== "commit") throw new Error("Expected commit")
       expect(incoming.proposals.map((p) => p.proposal)).toStrictEqual([customProposal])
@@ -260,31 +262,34 @@ async function authenticatedDataScenario(cipherSuite: CiphersuiteName) {
     throw new Error("Expected public message")
 
   const tamperedPublicProposal = {
-    ...bobProposalPublicResult.message.publicMessage,
-    content: {
-      ...bobProposalPublicResult.message.publicMessage.content,
-      authenticatedData: encoder.encode("aad-proposal-public-tampered"),
+    ...bobProposalPublicResult.message,
+    publicMessage: {
+      ...bobProposalPublicResult.message.publicMessage,
+      content: {
+        ...bobProposalPublicResult.message.publicMessage.content,
+        authenticatedData: encoder.encode("aad-proposal-public-tampered"),
+      },
     },
   }
 
   await expect(
-    processPublicMessage({
+    processMessageEnsureNoMutation({
       context: {
         cipherSuite: impl,
         authService: unsafeTestingAuthenticationService,
       },
       state: aliceGroup,
-      publicMessage: tamperedPublicProposal,
+      message: tamperedPublicProposal,
     }),
   ).rejects.toThrow(CryptoVerificationError)
 
-  const aliceProcessPublicProposalResult = await processPublicMessage({
+  const aliceProcessPublicProposalResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: aliceGroup,
-    publicMessage: bobProposalPublicResult.message.publicMessage,
+    message: bobProposalPublicResult.message,
     callback: (incoming) => {
       if (incoming.kind !== "proposal") throw new Error("Expected proposal")
       expect(incoming.proposal.proposal).toStrictEqual(customProposalPublic)
@@ -314,31 +319,34 @@ async function authenticatedDataScenario(cipherSuite: CiphersuiteName) {
     throw new Error("Expected public message")
 
   const tamperedPublicCommit = {
-    ...alicePublicCommitResult.commit.publicMessage,
-    content: {
-      ...alicePublicCommitResult.commit.publicMessage.content,
-      authenticatedData: encoder.encode("aad-commit-public-tampered"),
+    ...alicePublicCommitResult.commit,
+    publicMessage: {
+      ...alicePublicCommitResult.commit.publicMessage,
+      content: {
+        ...alicePublicCommitResult.commit.publicMessage.content,
+        authenticatedData: encoder.encode("aad-commit-public-tampered"),
+      },
     },
   }
 
   await expect(
-    processPublicMessage({
+    processMessageEnsureNoMutation({
       context: {
         cipherSuite: impl,
         authService: unsafeTestingAuthenticationService,
       },
       state: bobGroup,
-      publicMessage: tamperedPublicCommit,
+      message: tamperedPublicCommit,
     }),
   ).rejects.toThrow(CryptoVerificationError)
 
-  const bobProcessPublicCommitResult = await processPublicMessage({
+  const bobProcessPublicCommitResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    publicMessage: alicePublicCommitResult.commit.publicMessage,
+    message: alicePublicCommitResult.commit,
     callback: (incoming) => {
       if (incoming.kind !== "commit") throw new Error("Expected commit")
       expect(incoming.proposals.map((p) => p.proposal)).toStrictEqual([customProposalPublic])

--- a/test/scenario/common.ts
+++ b/test/scenario/common.ts
@@ -1,12 +1,12 @@
 import { ClientState } from "../../src/clientState.js"
 import { createApplicationMessage } from "../../src/createMessage.js"
-import { processMessage, ProcessMessageResult, processPrivateMessage } from "../../src/processMessages.js"
+import { processMessage, ProcessMessageResult } from "../../src/processMessages.js"
 import { CiphersuiteImpl } from "../../src/crypto/ciphersuite.js"
 import { UsageError } from "../../src/mlsError.js"
 import { unsafeTestingAuthenticationService } from "../../src/authenticationService.js"
 import { createCommit, CreateCommitParams, CreateCommitResult } from "../../src/createCommit.js"
 import { ratchetTreeEncoder } from "../../src/ratchetTree.js"
-import { encode, IncomingMessageCallback, MlsContext, MlsFramedMessage, PrivateMessage } from "../../src/index.js"
+import { encode, IncomingMessageCallback, MlsContext, MlsFramedMessage } from "../../src/index.js"
 import { fastEqual } from "../../src/util/byteArray.js"
 
 export async function testEveryoneCanMessageEveryone(
@@ -97,22 +97,6 @@ export async function processMessageEnsureNoMutation(params: {
   const encodedBefore = encode(ratchetTreeEncoder, params.state.ratchetTree)
 
   const res = await processMessage(params)
-
-  if (!fastEqual(encodedBefore, encode(ratchetTreeEncoder, params.state.ratchetTree))) {
-    throw new Error("Ratchet Tree should not change after commit")
-  }
-  return res
-}
-
-export async function processPrivateMessageEnsureNoMutation(params: {
-  context: MlsContext
-  state: ClientState
-  privateMessage: PrivateMessage
-  callback?: IncomingMessageCallback
-}): Promise<ProcessMessageResult> {
-  const encodedBefore = encode(ratchetTreeEncoder, params.state.ratchetTree)
-
-  const res = await processPrivateMessage(params)
 
   if (!fastEqual(encodedBefore, encode(ratchetTreeEncoder, params.state.ratchetTree))) {
     throw new Error("Ratchet Tree should not change after commit")

--- a/test/scenario/customProposal.test.ts
+++ b/test/scenario/customProposal.test.ts
@@ -7,7 +7,6 @@ import { Proposal, ProposalAdd } from "../../src/proposal.js"
 import {
   createCommitEnsureNoMutation,
   processMessageEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 import { Capabilities } from "../../src/capabilities.js"
@@ -147,10 +146,10 @@ async function customProposalTest(cipherSuite: CiphersuiteName) {
   if (createCommitResult.commit.wireformat !== wireformats.mls_private_message)
     throw new Error("Expected private message")
 
-  const processCommitResult = await processPrivateMessageEnsureNoMutation({
+  const processCommitResult = await processMessageEnsureNoMutation({
     context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
     state: bobGroup,
-    privateMessage: createCommitResult.commit.privateMessage,
+    message: createCommitResult.commit,
     callback: (p) => {
       if (p.kind !== "commit") throw new Error("Expected commit")
       expect(p.proposals.map((p) => p.proposal)).toStrictEqual([customProposal])

--- a/test/scenario/epochOutOfOrder.test.ts
+++ b/test/scenario/epochOutOfOrder.test.ts
@@ -9,7 +9,6 @@ import { ProposalAdd } from "../../src/proposal.js"
 import {
   createCommitEnsureNoMutation,
   processMessageEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
   shuffledIndices,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
@@ -166,14 +165,14 @@ async function epochOutOfOrder(cipherSuite: CiphersuiteName) {
     throw new Error("Expected private message")
 
   // alice processes the empty commit and goes to epoch 2
-  const aliceProcessFirstCommitResult = await processPrivateMessageEnsureNoMutation({
+  const aliceProcessFirstCommitResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
       clientConfig,
     },
     state: aliceGroup,
-    privateMessage: emptyCommitResult1.commit.privateMessage,
+    message: emptyCommitResult1.commit,
   })
   aliceGroup = aliceProcessFirstCommitResult.newState
 
@@ -200,14 +199,14 @@ async function epochOutOfOrder(cipherSuite: CiphersuiteName) {
     throw new Error("Expected private message")
 
   // alice processes the empty commit and goes to epoch 3
-  const aliceProcessSecondCommitResult = await processPrivateMessageEnsureNoMutation({
+  const aliceProcessSecondCommitResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
       clientConfig,
     },
     state: aliceGroup,
-    privateMessage: emptyCommitResult2.commit.privateMessage,
+    message: emptyCommitResult2.commit,
   })
   aliceGroup = aliceProcessSecondCommitResult.newState
 
@@ -234,14 +233,14 @@ async function epochOutOfOrder(cipherSuite: CiphersuiteName) {
     throw new Error("Expected private message")
 
   // alice processes the empty commit and goes to epoch 4
-  const aliceProcessThirdCommitResult = await processPrivateMessageEnsureNoMutation({
+  const aliceProcessThirdCommitResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
       clientConfig,
     },
     state: aliceGroup,
-    privateMessage: emptyCommitResult3.commit.privateMessage,
+    message: emptyCommitResult3.commit,
   })
   aliceGroup = aliceProcessThirdCommitResult.newState
 
@@ -339,14 +338,14 @@ async function epochOutOfOrderRandom(cipherSuite: CiphersuiteName, totalMessages
       throw new Error("Expected private message")
 
     // alice processes the empty commit and goes to next epoch
-    const aliceProcessCommitResult = await processPrivateMessageEnsureNoMutation({
+    const aliceProcessCommitResult = await processMessageEnsureNoMutation({
       context: {
         cipherSuite: impl,
         authService: unsafeTestingAuthenticationService,
         clientConfig,
       },
       state: aliceGroup,
-      privateMessage: emptyCommitResult.commit.privateMessage,
+      message: emptyCommitResult.commit,
     })
     aliceGroup = aliceProcessCommitResult.newState
     messages.push(createMessageResult.message)
@@ -409,14 +408,14 @@ async function epochOutOfOrderLimitFails(cipherSuite: CiphersuiteName, totalMess
       throw new Error("Expected private message")
 
     // alice processes the empty commit and goes to next epoch
-    const aliceProcessCommitResult = await processPrivateMessageEnsureNoMutation({
+    const aliceProcessCommitResult = await processMessageEnsureNoMutation({
       context: {
         cipherSuite: impl,
         authService: unsafeTestingAuthenticationService,
         clientConfig,
       },
       state: aliceGroup,
-      privateMessage: emptyCommitResult.commit.privateMessage,
+      message: emptyCommitResult.commit,
     })
     aliceGroup = aliceProcessCommitResult.newState
     messages.push(createMessageResult.message)

--- a/test/scenario/externalAddProposal.test.ts
+++ b/test/scenario/externalAddProposal.test.ts
@@ -1,6 +1,5 @@
 import { createGroup, joinGroup } from "../../src/clientState.js"
 import { createGroupInfoWithExternalPub } from "../../src/createCommit.js"
-import { processPublicMessage } from "../../src/processMessages.js"
 import { Credential } from "../../src/credential.js"
 import { defaultCredentialTypes } from "../../src/defaultCredentialType.js"
 import { CiphersuiteName, ciphersuites } from "../../src/crypto/ciphersuite.js"
@@ -10,7 +9,7 @@ import { ProposalAdd } from "../../src/proposal.js"
 import { checkHpkeKeysMatch } from "../crypto/keyMatch.js"
 import {
   createCommitEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 
@@ -98,24 +97,24 @@ async function externalAddProposalTest(cipherSuite: CiphersuiteName) {
 
   if (addCharlieProposal.wireformat !== wireformats.mls_public_message) throw new Error("Expected public message")
 
-  const aliceProcessCharlieProposalResult = await processPublicMessage({
+  const aliceProcessCharlieProposalResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: aliceGroup,
-    publicMessage: addCharlieProposal.publicMessage,
+    message: addCharlieProposal,
   })
 
   aliceGroup = aliceProcessCharlieProposalResult.newState
 
-  const bobProcessCharlieProposalResult = await processPublicMessage({
+  const bobProcessCharlieProposalResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    publicMessage: addCharlieProposal.publicMessage,
+    message: addCharlieProposal,
   })
 
   bobGroup = bobProcessCharlieProposalResult.newState
@@ -133,13 +132,13 @@ async function externalAddProposalTest(cipherSuite: CiphersuiteName) {
   if (addCharlieCommitResult.commit.wireformat !== wireformats.mls_private_message)
     throw new Error("Expected private message")
 
-  const processAddCharlieResult = await processPrivateMessageEnsureNoMutation({
+  const processAddCharlieResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    privateMessage: addCharlieCommitResult.commit.privateMessage,
+    message: addCharlieCommitResult.commit,
   })
 
   bobGroup = processAddCharlieResult.newState

--- a/test/scenario/externalJoin.test.ts
+++ b/test/scenario/externalJoin.test.ts
@@ -1,6 +1,5 @@
 import { createGroup, joinGroup } from "../../src/clientState.js"
 import { createGroupInfoWithExternalPubAndRatchetTree, joinGroupExternal } from "../../src/createCommit.js"
-import { processPublicMessage } from "../../src/processMessages.js"
 import { Credential } from "../../src/credential.js"
 import { defaultCredentialTypes } from "../../src/defaultCredentialType.js"
 import { CiphersuiteName, ciphersuites } from "../../src/crypto/ciphersuite.js"
@@ -8,7 +7,11 @@ import { getCiphersuiteImpl } from "../../src/crypto/getCiphersuiteImpl.js"
 import { generateKeyPackage } from "../../src/keyPackage.js"
 import { ProposalAdd } from "../../src/proposal.js"
 import { checkHpkeKeysMatch } from "../crypto/keyMatch.js"
-import { createCommitEnsureNoMutation, testEveryoneCanMessageEveryone } from "./common.js"
+import {
+  createCommitEnsureNoMutation,
+  processMessageEnsureNoMutation,
+  testEveryoneCanMessageEveryone,
+} from "./common.js"
 
 import { defaultProposalTypes } from "../../src/defaultProposalType.js"
 import { unsafeTestingAuthenticationService } from "../../src/authenticationService.js"
@@ -102,24 +105,24 @@ async function externalJoin(cipherSuite: CiphersuiteName) {
 
   const charlieGroup = charlieJoinGroupCommitResult.newState
 
-  const aliceProcessCharlieJoinResult = await processPublicMessage({
+  const aliceProcessCharlieJoinResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: aliceGroup,
-    publicMessage: charlieJoinGroupCommitResult.publicMessage,
+    message: charlieJoinGroupCommitResult.commit,
   })
 
   aliceGroup = aliceProcessCharlieJoinResult.newState
 
-  const bobProcessCharlieJoinResult = await processPublicMessage({
+  const bobProcessCharlieJoinResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    publicMessage: charlieJoinGroupCommitResult.publicMessage,
+    message: charlieJoinGroupCommitResult.commit,
   })
 
   bobGroup = bobProcessCharlieJoinResult.newState

--- a/test/scenario/externalJoinResync.test.ts
+++ b/test/scenario/externalJoinResync.test.ts
@@ -1,6 +1,5 @@
 import { createGroup, joinGroup } from "../../src/clientState.js"
 import { createGroupInfoWithExternalPubAndRatchetTree, joinGroupExternal } from "../../src/createCommit.js"
-import { processPublicMessage } from "../../src/processMessages.js"
 import { Credential } from "../../src/credential.js"
 import { defaultCredentialTypes } from "../../src/defaultCredentialType.js"
 import { CiphersuiteName, ciphersuites } from "../../src/crypto/ciphersuite.js"
@@ -8,7 +7,11 @@ import { getCiphersuiteImpl } from "../../src/crypto/getCiphersuiteImpl.js"
 import { generateKeyPackage } from "../../src/keyPackage.js"
 import { ProposalAdd } from "../../src/proposal.js"
 import { checkHpkeKeysMatch } from "../crypto/keyMatch.js"
-import { createCommitEnsureNoMutation, testEveryoneCanMessageEveryone } from "./common.js"
+import {
+  createCommitEnsureNoMutation,
+  processMessageEnsureNoMutation,
+  testEveryoneCanMessageEveryone,
+} from "./common.js"
 
 import { defaultProposalTypes } from "../../src/defaultProposalType.js"
 import { unsafeTestingAuthenticationService } from "../../src/authenticationService.js"
@@ -159,24 +162,24 @@ async function externalJoinResyncTest(cipherSuite: CiphersuiteName) {
 
   charlieGroup = charlieResyncCommitResult.newState
 
-  const aliceProcessCharlieResyncResult = await processPublicMessage({
+  const aliceProcessCharlieResyncResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: aliceGroup,
-    publicMessage: charlieResyncCommitResult.publicMessage,
+    message: charlieResyncCommitResult.commit,
   })
 
   aliceGroup = aliceProcessCharlieResyncResult.newState
 
-  const bobProcessCharlieResyncResult = await processPublicMessage({
+  const bobProcessCharlieResyncResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    publicMessage: charlieResyncCommitResult.publicMessage,
+    message: charlieResyncCommitResult.commit,
   })
 
   bobGroup = bobProcessCharlieResyncResult.newState

--- a/test/scenario/externalProposal.test.ts
+++ b/test/scenario/externalProposal.test.ts
@@ -1,6 +1,5 @@
 import { createGroup, joinGroup } from "../../src/clientState.js"
 import { createGroupInfoWithExternalPub } from "../../src/createCommit.js"
-import { processPublicMessage } from "../../src/processMessages.js"
 import { Credential } from "../../src/credential.js"
 import { defaultCredentialTypes } from "../../src/defaultCredentialType.js"
 import { CiphersuiteName, ciphersuites } from "../../src/crypto/ciphersuite.js"
@@ -16,7 +15,7 @@ import { defaultProposalTypes } from "../../src/defaultProposalType.js"
 import { defaultExtensionTypes } from "../../src/defaultExtensionType.js"
 import { wireformats } from "../../src/wireformat.js"
 import { unsafeTestingAuthenticationService } from "../../src/authenticationService.js"
-import { createCommitEnsureNoMutation, processPrivateMessageEnsureNoMutation } from "./common.js"
+import { createCommitEnsureNoMutation, processMessageEnsureNoMutation } from "./common.js"
 
 test.concurrent.each(Object.keys(ciphersuites))(`External Proposal %s`, async (cs) => {
   await externalProposalTest(cs as CiphersuiteName)
@@ -121,24 +120,24 @@ async function externalProposalTest(cipherSuite: CiphersuiteName) {
 
   if (addCharlieProposal.wireformat !== wireformats.mls_public_message) throw new Error("Expected public message")
 
-  const aliceProcessCharlieProposalResult = await processPublicMessage({
+  const aliceProcessCharlieProposalResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: aliceGroup,
-    publicMessage: addCharlieProposal.publicMessage,
+    message: addCharlieProposal,
   })
 
   aliceGroup = aliceProcessCharlieProposalResult.newState
 
-  const bobProcessCharlieProposalResult = await processPublicMessage({
+  const bobProcessCharlieProposalResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    publicMessage: addCharlieProposal.publicMessage,
+    message: addCharlieProposal,
   })
 
   bobGroup = bobProcessCharlieProposalResult.newState
@@ -156,13 +155,13 @@ async function externalProposalTest(cipherSuite: CiphersuiteName) {
   if (removeBobCommitResult.commit.wireformat !== wireformats.mls_private_message)
     throw new Error("Expected private message")
 
-  const processRemoveBobResult = await processPrivateMessageEnsureNoMutation({
+  const processRemoveBobResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    privateMessage: removeBobCommitResult.commit.privateMessage,
+    message: removeBobCommitResult.commit,
   })
 
   bobGroup = processRemoveBobResult.newState

--- a/test/scenario/externalProposalMultipleSenders.test.ts
+++ b/test/scenario/externalProposalMultipleSenders.test.ts
@@ -1,6 +1,5 @@
 import { createGroup, joinGroup } from "../../src/clientState.js"
 import { createGroupInfoWithExternalPub } from "../../src/createCommit.js"
-import { processPublicMessage } from "../../src/processMessages.js"
 import { Credential } from "../../src/credential.js"
 import { defaultCredentialTypes } from "../../src/defaultCredentialType.js"
 import { CiphersuiteName, ciphersuites } from "../../src/crypto/ciphersuite.js"
@@ -14,7 +13,7 @@ import { defaultProposalTypes } from "../../src/defaultProposalType.js"
 import { defaultExtensionTypes } from "../../src/defaultExtensionType.js"
 import { wireformats } from "../../src/wireformat.js"
 import { unsafeTestingAuthenticationService } from "../../src/authenticationService.js"
-import { createCommitEnsureNoMutation } from "./common.js"
+import { createCommitEnsureNoMutation, processMessageEnsureNoMutation } from "./common.js"
 
 test.concurrent.each(Object.keys(ciphersuites))(`External proposal with multiple senders %s`, async (cs) => {
   await externalProposalMultipleSendersTest(cs as CiphersuiteName)
@@ -104,17 +103,17 @@ async function externalProposalMultipleSendersTest(cipherSuite: CiphersuiteName)
 
   // Both members must validate the signature, which requires senderFromExtension
   // to look up index 1 inside extensionData.
-  const aliceProcess = await processPublicMessage({
+  const aliceProcess = await processMessageEnsureNoMutation({
     context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
     state: aliceGroup,
-    publicMessage: externalProposalMsg.publicMessage,
+    message: externalProposalMsg,
   })
   aliceGroup = aliceProcess.newState
 
-  const bobProcess = await processPublicMessage({
+  const bobProcess = await processMessageEnsureNoMutation({
     context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
     state: bobGroup,
-    publicMessage: externalProposalMsg.publicMessage,
+    message: externalProposalMsg,
   })
   bobGroup = bobProcess.newState
 

--- a/test/scenario/externalPsk.test.ts
+++ b/test/scenario/externalPsk.test.ts
@@ -10,7 +10,7 @@ import { bytesToBase64 } from "../../src/util/byteArray.js"
 import { checkHpkeKeysMatch } from "../crypto/keyMatch.js"
 import {
   createCommitEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 
@@ -132,14 +132,14 @@ async function externalPsk(cipherSuite: CiphersuiteName) {
 
   if (pskCommitResult.commit.wireformat !== wireformats.mls_private_message) throw new Error("Expected private message")
 
-  const processPskResult = await processPrivateMessageEnsureNoMutation({
+  const processPskResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
       externalPsks: sharedPsks,
     },
     state: bobGroup,
-    privateMessage: pskCommitResult.commit.privateMessage,
+    message: pskCommitResult.commit,
   })
 
   bobGroup = processPskResult.newState

--- a/test/scenario/groupContextExtensionsCommit.test.ts
+++ b/test/scenario/groupContextExtensionsCommit.test.ts
@@ -10,7 +10,7 @@ import { defaultExtensionTypes } from "../../src/defaultExtensionType.js"
 import { unsafeTestingAuthenticationService } from "../../src/authenticationService.js"
 import {
   createCommitEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 import { wireformats } from "../../src/wireformat.js"
@@ -111,17 +111,17 @@ async function groupContextExtensionsCommitTest(cipherSuite: CiphersuiteName) {
 
   if (gceCommit.commit.wireformat !== wireformats.mls_private_message) throw new Error("Expected private message")
 
-  const bobProcess = await processPrivateMessageEnsureNoMutation({
+  const bobProcess = await processMessageEnsureNoMutation({
     context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
     state: bobGroup,
-    privateMessage: gceCommit.commit.privateMessage,
+    message: gceCommit.commit,
   })
   bobGroup = bobProcess.newState
 
-  const charlieProcess = await processPrivateMessageEnsureNoMutation({
+  const charlieProcess = await processMessageEnsureNoMutation({
     context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
     state: charlieGroup,
-    privateMessage: gceCommit.commit.privateMessage,
+    message: gceCommit.commit,
   })
   charlieGroup = charlieProcess.newState
 
@@ -213,10 +213,10 @@ async function emptyGroupContextExtensionsCommitTest(cipherSuite: CiphersuiteNam
   if (addExtensionsCommit.commit.wireformat !== wireformats.mls_private_message)
     throw new Error("Expected private message")
 
-  const bobAddProcess = await processPrivateMessageEnsureNoMutation({
+  const bobAddProcess = await processMessageEnsureNoMutation({
     context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
     state: bobGroup,
-    privateMessage: addExtensionsCommit.commit.privateMessage,
+    message: addExtensionsCommit.commit,
   })
   bobGroup = bobAddProcess.newState
 
@@ -237,10 +237,10 @@ async function emptyGroupContextExtensionsCommitTest(cipherSuite: CiphersuiteNam
 
   if (clearCommit.commit.wireformat !== wireformats.mls_private_message) throw new Error("Expected private message")
 
-  const bobClearProcess = await processPrivateMessageEnsureNoMutation({
+  const bobClearProcess = await processMessageEnsureNoMutation({
     context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
     state: bobGroup,
-    privateMessage: clearCommit.commit.privateMessage,
+    message: clearCommit.commit,
   })
   bobGroup = bobClearProcess.newState
 

--- a/test/scenario/largeGroupFullLifecycle.test.ts
+++ b/test/scenario/largeGroupFullLifecycle.test.ts
@@ -7,7 +7,7 @@ import { defaultCredentialTypes } from "../../src/defaultCredentialType.js"
 import { ProposalAdd, ProposalRemove } from "../../src/proposal.js"
 import {
   createCommitEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   shuffledIndices,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
@@ -125,13 +125,13 @@ async function largeGroupFullLifecycle(cipherSuite: CiphersuiteName, initialSize
     for (let i = 0; i < memberStates.length; i++) {
       if (i === removerIndex) continue
       const m = memberStates[i]!
-      const result = await processPrivateMessageEnsureNoMutation({
+      const result = await processMessageEnsureNoMutation({
         context: {
           cipherSuite: impl,
           authService: unsafeTestingAuthenticationService,
         },
         state: m.state,
-        privateMessage: commitResult.commit.privateMessage,
+        message: commitResult.commit,
       })
       m.state = result.newState
     }
@@ -189,13 +189,13 @@ async function addMember(memberStates: MemberState[], index: number, impl: Ciphe
   for (let i = 0; i < memberStates.length; i++) {
     if (i === adderIndex) continue
     const m = memberStates[i]!
-    const result = await processPrivateMessageEnsureNoMutation({
+    const result = await processMessageEnsureNoMutation({
       context: {
         cipherSuite: impl,
         authService: unsafeTestingAuthenticationService,
       },
       state: m.state,
-      privateMessage: commitResult.commit.privateMessage,
+      message: commitResult.commit,
     })
 
     m.state = result.newState
@@ -225,13 +225,13 @@ async function update(memberStates: MemberState[], updateIndex: number, impl: Ci
   for (let i = 0; i < memberStates.length; i++) {
     if (i === updateIndex) continue
     const m = memberStates[i]!
-    const result = await processPrivateMessageEnsureNoMutation({
+    const result = await processMessageEnsureNoMutation({
       context: {
         cipherSuite: impl,
         authService: unsafeTestingAuthenticationService,
       },
       state: m.state,
-      privateMessage: emptyCommitResult.commit.privateMessage,
+      message: emptyCommitResult.commit,
     })
 
     m.state = result.newState

--- a/test/scenario/reinit.test.ts
+++ b/test/scenario/reinit.test.ts
@@ -10,7 +10,7 @@ import { checkHpkeKeysMatch } from "../crypto/keyMatch.js"
 import {
   createCommitEnsureNoMutation,
   getRandomElement,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 
@@ -98,13 +98,13 @@ async function reinit(cipherSuite: CiphersuiteName) {
   if (reinitCommitResult.commit.wireformat !== wireformats.mls_private_message)
     throw new Error("Expected private message")
 
-  const processReinitResult = await processPrivateMessageEnsureNoMutation({
+  const processReinitResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    privateMessage: reinitCommitResult.commit.privateMessage,
+    message: reinitCommitResult.commit,
   })
 
   bobGroup = processReinitResult.newState

--- a/test/scenario/remove.test.ts
+++ b/test/scenario/remove.test.ts
@@ -9,7 +9,7 @@ import { checkHpkeKeysMatch } from "../crypto/keyMatch.js"
 import {
   cannotMessageAnymore,
   createCommitEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 
@@ -132,25 +132,25 @@ async function remove(cipherSuite: CiphersuiteName) {
   if (removeBobCommitResult.commit.wireformat !== wireformats.mls_private_message)
     throw new Error("Expected private message")
 
-  const bobProcessCommitResult = await processPrivateMessageEnsureNoMutation({
+  const bobProcessCommitResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    privateMessage: removeBobCommitResult.commit.privateMessage,
+    message: removeBobCommitResult.commit,
   })
 
   // bob is removed here
   bobGroup = bobProcessCommitResult.newState
 
-  const charlieProcessCommitResult = await processPrivateMessageEnsureNoMutation({
+  const charlieProcessCommitResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: charlieGroup,
-    privateMessage: removeBobCommitResult.commit.privateMessage,
+    message: removeBobCommitResult.commit,
   })
 
   charlieGroup = charlieProcessCommitResult.newState

--- a/test/scenario/resumptionOptions.test.ts
+++ b/test/scenario/resumptionOptions.test.ts
@@ -12,7 +12,7 @@ import { wireformats } from "../../src/wireformat.js"
 import { pskTypes, resumptionPSKUsages } from "../../src/presharedkey.js"
 import {
   createCommitEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 
@@ -124,10 +124,10 @@ async function selfResumptionPskTest(cipherSuite: CiphersuiteName) {
 
   if (commit.commit.wireformat !== wireformats.mls_private_message) throw new Error("Expected private message")
 
-  const bobAfter = await processPrivateMessageEnsureNoMutation({
+  const bobAfter = await processMessageEnsureNoMutation({
     context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
     state: bobGroup,
-    privateMessage: commit.commit.privateMessage,
+    message: commit.commit,
   })
 
   expect(bobAfter.newState.keySchedule.epochAuthenticator).toStrictEqual(commit.newState.keySchedule.epochAuthenticator)

--- a/test/scenario/threePartyJoin.test.ts
+++ b/test/scenario/threePartyJoin.test.ts
@@ -9,7 +9,7 @@ import { ProposalAdd } from "../../src/proposal.js"
 import { checkHpkeKeysMatch } from "../crypto/keyMatch.js"
 import {
   createCommitEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 
@@ -111,13 +111,13 @@ async function threePartyJoin(cipherSuite: CiphersuiteName) {
   if (addCharlieCommitResult.commit.wireformat !== wireformats.mls_private_message)
     throw new Error("Expected private message")
 
-  const processAddCharlieResult = await processPrivateMessageEnsureNoMutation({
+  const processAddCharlieResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    privateMessage: addCharlieCommitResult.commit.privateMessage,
+    message: addCharlieCommitResult.commit,
   })
 
   bobGroup = processAddCharlieResult.newState

--- a/test/scenario/update.test.ts
+++ b/test/scenario/update.test.ts
@@ -8,7 +8,7 @@ import { ProposalAdd } from "../../src/proposal.js"
 import { checkHpkeKeysMatch } from "../crypto/keyMatch.js"
 import {
   createCommitEnsureNoMutation,
-  processPrivateMessageEnsureNoMutation,
+  processMessageEnsureNoMutation,
   testEveryoneCanMessageEveryone,
 } from "./common.js"
 
@@ -93,13 +93,13 @@ async function update(cipherSuite: CiphersuiteName) {
 
   aliceGroup = emptyCommitResult.newState
 
-  const bobProcessCommitResult = await processPrivateMessageEnsureNoMutation({
+  const bobProcessCommitResult = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: bobGroup,
-    privateMessage: emptyCommitResult.commit.privateMessage,
+    message: emptyCommitResult.commit,
   })
 
   bobGroup = bobProcessCommitResult.newState
@@ -117,13 +117,13 @@ async function update(cipherSuite: CiphersuiteName) {
 
   bobGroup = emptyCommitResult3.newState
 
-  const aliceProcessCommitResult3 = await processPrivateMessageEnsureNoMutation({
+  const aliceProcessCommitResult3 = await processMessageEnsureNoMutation({
     context: {
       cipherSuite: impl,
       authService: unsafeTestingAuthenticationService,
     },
     state: aliceGroup,
-    privateMessage: emptyCommitResult3.commit.privateMessage,
+    message: emptyCommitResult3.commit,
   })
 
   aliceGroup = aliceProcessCommitResult3.newState

--- a/test/test-vectors/passiveClientScenarios.test.ts
+++ b/test/test-vectors/passiveClientScenarios.test.ts
@@ -9,11 +9,12 @@ import { mlsMessageDecoder } from "../../src/message.js"
 import { ratchetTreeDecoder } from "../../src/ratchetTree.js"
 
 import { joinGroup } from "../../src/clientState.js"
-import { processPrivateMessage, processPublicMessage } from "../../src/processMessages.js"
+
 import { bytesToBase64 } from "../../src/util/byteArray.js"
 import { wireformats } from "../../src/wireformat.js"
 import { unsafeTestingAuthenticationService } from "../../src/authenticationService.js"
 import { defaultCryptoProvider } from "../../src/index.js"
+import { processMessageEnsureNoMutation } from "../scenario/common.js"
 
 test.concurrent.each(jsonCommit.map((x, index) => [index, x]))(
   `passive-client-handling-commit test vectors %i`,
@@ -88,31 +89,17 @@ async function testPassiveClientScenario(data: MlsGroupState, impl: CiphersuiteI
       )
         throw new Error("Could not decode proposal message")
 
-      if (mlsProposal[0].wireformat === wireformats.mls_private_message) {
-        const res = await processPrivateMessage({
-          context: {
-            cipherSuite: impl,
-            authService: unsafeTestingAuthenticationService,
-            externalPsks: psks,
-          },
-          state,
-          privateMessage: mlsProposal[0].privateMessage,
-        })
+      const res = await processMessageEnsureNoMutation({
+        context: {
+          cipherSuite: impl,
+          authService: unsafeTestingAuthenticationService,
+          externalPsks: psks,
+        },
+        state,
+        message: mlsProposal[0],
+      })
 
-        state = res.newState
-      } else {
-        const res = await processPublicMessage({
-          context: {
-            cipherSuite: impl,
-            authService: unsafeTestingAuthenticationService,
-            externalPsks: psks,
-          },
-          state,
-          publicMessage: mlsProposal[0].publicMessage,
-        })
-
-        state = res.newState
-      }
+      state = res.newState
     }
 
     const mlsCommit = mlsMessageDecoder(hexToBytes(epoch.commit), 0)
@@ -123,30 +110,17 @@ async function testPassiveClientScenario(data: MlsGroupState, impl: CiphersuiteI
     )
       throw new Error("Could not decode commit message")
 
-    if (mlsCommit[0].wireformat === wireformats.mls_private_message) {
-      const res = await processPrivateMessage({
-        context: {
-          cipherSuite: impl,
-          authService: unsafeTestingAuthenticationService,
-          externalPsks: psks,
-        },
-        state,
-        privateMessage: mlsCommit[0].privateMessage,
-      })
+    const res = await processMessageEnsureNoMutation({
+      context: {
+        cipherSuite: impl,
+        authService: unsafeTestingAuthenticationService,
+        externalPsks: psks,
+      },
+      state,
+      message: mlsCommit[0],
+    })
 
-      state = res.newState
-    } else {
-      const res = await processPublicMessage({
-        context: {
-          cipherSuite: impl,
-          authService: unsafeTestingAuthenticationService,
-          externalPsks: psks,
-        },
-        state,
-        publicMessage: mlsCommit[0].publicMessage,
-      })
-      state = res.newState
-    }
+    state = res.newState
 
     expect(state.keySchedule.epochAuthenticator).toStrictEqual(hexToBytes(epoch.epoch_authenticator))
   }


### PR DESCRIPTION
Also aligns the joinGroupExternal with the other commit creation functions.