### PR TITLE
Accept Update proposals from the member at leaf index 0

### DIFF
--- a/src/clientState.ts
+++ b/src/clientState.ts
@@ -867,7 +867,7 @@ export async function processProposal(
         )
         break
       case defaultProposalTypes.update:
-        if (!senderLeafIndex) throw new ValidationError("Received an Update proposal from a non-member")
+        if (senderLeafIndex === undefined) throw new ValidationError("Received an Update proposal from a non-member")
         await validateUpdateProposal(
           proposal,
           senderLeafIndex,

--- a/test/scenario/updateProposal.test.ts
+++ b/test/scenario/updateProposal.test.ts
@@ -37,6 +37,116 @@ test.concurrent.each(Object.keys(ciphersuites))(`Update Proposal %s`, async (cs)
   await updateProposalRoundtrip(cs as CiphersuiteName, false)
 })
 
+test.concurrent.each(Object.keys(ciphersuites))(`Update Proposal from leaf index zero %s`, async (cs) => {
+  await updateProposalFromLeafZero(cs as CiphersuiteName, true)
+  await updateProposalFromLeafZero(cs as CiphersuiteName, false)
+})
+
+// The member at leaf index 0 sends an Update proposal by reference and another member commits it
+async function updateProposalFromLeafZero(cipherSuite: CiphersuiteName, publicMessage: boolean) {
+  const impl = await getCiphersuiteImpl(cipherSuite)
+  const preferredWireformat = publicMessage ? wireformats.mls_public_message : wireformats.mls_private_message
+
+  const aliceCredential: Credential = {
+    credentialType: defaultCredentialTypes.basic,
+    identity: new TextEncoder().encode("alice"),
+  }
+  const alice = await generateKeyPackage({ credential: aliceCredential, cipherSuite: impl })
+
+  let aliceGroup = await createGroup({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+    groupId: new TextEncoder().encode("group1"),
+    keyPackage: alice.publicPackage,
+    privateKeyPackage: alice.privatePackage,
+  })
+
+  const bobCredential: Credential = {
+    credentialType: defaultCredentialTypes.basic,
+    identity: new TextEncoder().encode("bob"),
+  }
+  const bob = await generateKeyPackage({ credential: bobCredential, cipherSuite: impl })
+
+  const addBob: ProposalAdd = {
+    proposalType: defaultProposalTypes.add,
+    add: { keyPackage: bob.publicPackage },
+  }
+
+  const addBobCommit = await createCommitEnsureNoMutation({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+    state: aliceGroup,
+    wireAsPublicMessage: publicMessage,
+    extraProposals: [addBob],
+    ratchetTreeExtension: true,
+  })
+  aliceGroup = addBobCommit.newState
+
+  let bobGroup = await joinGroup({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+    welcome: addBobCommit.welcome!.welcome,
+    keyPackage: bob.publicPackage,
+    privateKeys: bob.privatePackage,
+  })
+  expect(bobGroup.keySchedule.epochAuthenticator).toStrictEqual(aliceGroup.keySchedule.epochAuthenticator)
+
+  expect(aliceGroup.privatePath.leafIndex).toBe(0)
+  expect(bobGroup.privatePath.leafIndex).toBe(1)
+
+  const aliceOldPub = getOwnLeafNode(aliceGroup).hpkePublicKey
+
+  const aliceUpdate = await createUpdateProposal({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+    state: aliceGroup,
+    wireAsPublicMessage: publicMessage,
+  })
+  aliceGroup = aliceUpdate.newState
+
+  if (aliceUpdate.message.wireformat !== preferredWireformat) throw new Error(`Expected ${preferredWireformat} message`)
+  expect(fastEqual(aliceUpdate.newLeafKeypair.hpkePublicKey, aliceOldPub)).toBe(false)
+
+  aliceGroup = {
+    ...aliceGroup,
+    privatePath: updateLeafKey(aliceGroup.privatePath, aliceUpdate.newLeafKeypair.hpkePrivateKey),
+  }
+
+  // bob must accept the proposal even though its sender sits at leaf index 0
+  const bobProcessProposal = await processMessageEnsureNoMutation({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+    state: bobGroup,
+    message: aliceUpdate.message,
+    callback: acceptAll,
+  })
+  bobGroup = bobProcessProposal.newState
+  expect(Object.keys(bobGroup.unappliedProposals).length).toBe(1)
+
+  const bobCommit = await createCommitEnsureNoMutation({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+    state: bobGroup,
+    wireAsPublicMessage: publicMessage,
+    ratchetTreeExtension: false,
+  })
+  bobGroup = bobCommit.newState
+  if (bobCommit.commit.wireformat !== preferredWireformat) throw new Error(`Expected ${preferredWireformat} message`)
+
+  const aliceProcessCommit = await processMessageEnsureNoMutation({
+    context: { cipherSuite: impl, authService: unsafeTestingAuthenticationService },
+    state: aliceGroup,
+    message: bobCommit.commit,
+    callback: acceptAll,
+  })
+  aliceGroup = aliceProcessCommit.newState
+
+  const aliceLeafAfter = getOwnLeafNode(aliceGroup)
+  expect(fastEqual(aliceLeafAfter.hpkePublicKey, aliceUpdate.newLeafKeypair.hpkePublicKey)).toBe(true)
+
+  expect(bobGroup.keySchedule.epochAuthenticator).toStrictEqual(aliceGroup.keySchedule.epochAuthenticator)
+  expect(aliceGroup.unappliedProposals).toEqual({})
+  expect(bobGroup.unappliedProposals).toEqual({})
+
+  await checkHpkeKeysMatch(aliceGroup, impl)
+  await checkHpkeKeysMatch(bobGroup, impl)
+  await testEveryoneCanMessageEveryone([aliceGroup, bobGroup], impl)
+}
+
 async function updateProposalRoundtrip(cipherSuite: CiphersuiteName, publicMessage: boolean) {
   const impl = await getCiphersuiteImpl(cipherSuite)
   const preferredWireformat = publicMessage ? wireformats.mls_public_message : wireformats.mls_private_message


### PR DESCRIPTION
Fixes #646.

`processProposal` in `src/clientState.ts` guards the update case with a falsy check:

```ts
if (!senderLeafIndex) throw new ValidationError("Received an Update proposal from a non-member")
```

`LeafIndex` is `Brand<number, "LeafIndex">`, i.e. a plain number at runtime, so leaf index 0
is falsy and takes the non-member branch. The effect is that every other member rejects a
by-reference `Update` proposal sent by the member sitting at leaf 0 — normally the group
creator. Members at leaf 1 and above are unaffected, which is why the existing suite did not
catch it: `test/scenario/updateProposal.test.ts` only ever has Bob (leaf 1) update.

The one-line fix is to check for `undefined`, which is what `groupProposals` a few hundred
lines up already does for the same value:

```ts
if (cur.senderLeafIndex === undefined) throw new ValidationError("Update Proposal requires a sender")
```

## Regression test

Added `Update Proposal from leaf index zero` to `test/scenario/updateProposal.test.ts`,
alongside the existing roundtrip test and in the same style: Alice creates the group (asserted
at leaf 0), adds Bob (asserted at leaf 1), Alice issues an `Update` proposal by reference, Bob
processes it, Bob commits it, Alice processes the commit, and both converge. It runs over every
ciphersuite and both wireformats, like its neighbour.

## Verification

- Mutation check: with only the `src/clientState.ts` line reverted, the new test fails on all
  19 ciphersuites with `ValidationError: Received an Update proposal from a non-member` thrown
  at `src/clientState.ts:870`. With the fix, all 19 pass.
- Full suite on this branch: `pnpm test` — 124 files, 2543 tests, 0 failures.
- `pnpm typecheck`, `pnpm lint` and `pnpm format:check` are clean.
